### PR TITLE
bordel: Commits leftover from initial repository

### DIFF
--- a/bin/cmds/stage
+++ b/bin/cmds/stage
@@ -314,12 +314,16 @@ stage_describe() {
 # Usage: stage_usage
 # Display usage for this command wrapper.
 stage_usage() {
-    echo "Stagging command list:"
-    echo "  iso-old: Copy BIOS/ISO installer related build results, from Bitbake deployment directory to the staging area."
-    echo "  iso: Copy EFI/ISO installer related build results, from Bitbake deployment directory to the staging area."
-    echo "  pxe-old: Copy PXE files for the installer from Bitbake deployment directory to the staging area."
-    echo "  pxe: Copy PXE files for the installer from Bitbake deployment directory to the staging area."
-    echo "  repository: Copy build results from Bitbake deployment directory to the staging area and update the relevant meta-data."
+    cat - <<EOF
+Usage: stage <command> ...
+    Run a stage command to populate STAGING_DIR with the build outputs.
+Stage Commands:
+    iso-old: Copy BIOS/ISO installer related build results, from Bitbake deployment directory to the staging area.
+    iso: Copy EFI/ISO installer related build results, from Bitbake deployment directory to the staging area.
+    pxe-old: Copy PXE files for the installer from Bitbake deployment directory to the staging area.
+    pxe: Copy PXE files for the installer from Bitbake deployment directory to the staging area.
+    repository: Copy build results from Bitbake deployment directory to the staging area and update the relevant meta-data.
+EOF
     exit $1
 }
 

--- a/bin/cmds/stage
+++ b/bin/cmds/stage
@@ -328,22 +328,22 @@ stage_need_conf() { return 0; }
 # Usage: stage <command>
 # Stage commands wrapper.
 stage_main() {
-    target="$1"
-    shift 1
-    case "${target}" in
-        "iso-old") check_cmd_version "${target}"
-                   stage_iso xenclient-dom0 ;;
-        "iso") check_cmd_version "${target}"
-               stage_iso openxt-installer ;;
-        "pxe-old") check_cmd_version "${target}"
-                   stage_pxe xenclient-dom0 ;;
-        "pxe") check_cmd_version "${target}"
-               stage_pxe openxt-installer ;;
-        "repository") stage_repository ;;
-        "help") stage_usage 0 ;;
-        *)  echo "Unknown staging command \`${target}'." >&2
-            stage_usage 1
-            ;;
-    esac
+    for target in $@; do
+        case "${target}" in
+            "iso-old") check_cmd_version "${target}"
+                       stage_iso xenclient-dom0 ;;
+            "iso") check_cmd_version "${target}"
+                   stage_iso openxt-installer ;;
+            "pxe-old") check_cmd_version "${target}"
+                       stage_pxe xenclient-dom0 ;;
+            "pxe") check_cmd_version "${target}"
+                   stage_pxe openxt-installer ;;
+            "repository") stage_repository ;;
+            "help") stage_usage 0 ;;
+            *)  echo "Unknown staging command \`${target}'." >&2
+                stage_usage 1
+                ;;
+        esac
+    done
 }
 

--- a/bin/cmds/stage
+++ b/bin/cmds/stage
@@ -227,13 +227,15 @@ stage_iso() {
     mmd -i ${efi_img} EFI/BOOT
 
     # The grub efi binary ends up with two different names depedning on 32bit
-    # or 64bit build. To aviod having to attempt to determine what kind of
+    # or 64bit build. To avoid having to attempt to determine what kind of
     # build was used, copy the 32bit named version if it exists and then
     # overwrite with 64bit named version if it exists.
-    [ -e "${images_dir}/${machine}/grubx64.efi" ] &&
-        mcopy -i "${efi_img}" "${images_dir}/${machine}/grubx64.efi" ::EFI/BOOT/BOOTX64.EFI
-    [ -e "${images_dir}/${machine}/grub-efi-bootx64.efi" ] &&
-        mcopy -i "${efi_img}" "${images_dir}/${machine}/grub-efi-bootx64.efi" ::EFI/BOOT/BOOTX64.EFI
+    if [ -e "${IMAGES_DIR}/${machine}/grubx64.efi" ]; then
+        mcopy -v -i "${efi_img}" "${IMAGES_DIR}/${machine}/grubx64.efi" ::EFI/BOOT/BOOTX64.EFI
+    fi
+    if [ -e "${IMAGES_DIR}/${machine}/grub-efi-bootx64.efi" ]; then
+        mcopy -v -i "${efi_img}" "${IMAGES_DIR}/${machine}/grub-efi-bootx64.efi" ::EFI/BOOT/BOOTX64.EFI
+    fi
 
     # --- Stage hybrid MBR image.
     local isohdp_src="${machine}/isohdpfx.bin"

--- a/templates/master/openxt.conf
+++ b/templates/master/openxt.conf
@@ -5,7 +5,7 @@ OPENXT_BUILD_ID="0"
 OPENXT_VERSION="9.0.0"
 # Name Refering to the release (purely cosmetic).
 # https://randomword.com/
-OPENXT_RELEASE="gabion"
+OPENXT_RELEASE="agrypnotic"
 # List of OpenXT versions that can be upgraded to this one (${OPENXT_VERSION}).
 OPENXT_UPGRADEABLE_RELEASES="8.0.0 8.0.1 8.0.2 9.0.0"
 # OpenXT branch name.

--- a/templates/master/openxt.conf
+++ b/templates/master/openxt.conf
@@ -2,7 +2,7 @@
 # Numeral: incremental, starting from the given number.
 OPENXT_BUILD_ID="0"
 # OpenXT version number. This will influence the upgrade path.
-OPENXT_VERSION="9.0.0"
+OPENXT_VERSION="10.0.0"
 # Name Refering to the release (purely cosmetic).
 # https://randomword.com/
 OPENXT_RELEASE="agrypnotic"

--- a/templates/stable-6/openxt.conf
+++ b/templates/stable-6/openxt.conf
@@ -9,4 +9,4 @@ OPENXT_RELEASE="mimetic"
 # List of OpenXT versions that can be upgraded to this one (${OPENXT_VERSION}).
 OPENXT_UPGRADEABLE_RELEASES="5.0.0"
 # OpenXT branch name.
-OPENXT_BUILD_BRANCH="stable-8"
+OPENXT_BUILD_BRANCH="stable-6"

--- a/templates/stable-7/openxt.conf
+++ b/templates/stable-7/openxt.conf
@@ -9,4 +9,4 @@ OPENXT_RELEASE="limosis"
 # List of OpenXT versions that can be upgraded to this one (${OPENXT_VERSION}).
 OPENXT_UPGRADEABLE_RELEASES="6.0.0"
 # OpenXT branch name.
-OPENXT_BUILD_BRANCH="stable-8"
+OPENXT_BUILD_BRANCH="stable-7"

--- a/templates/stable-8/local.conf
+++ b/templates/stable-8/local.conf
@@ -56,6 +56,7 @@ MIRRORS += " \
     http://code.coreboot.org/p/seabios/downloads/.*     https://www.seabios.org/downloads/ \n \
     http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
     git://anonscm.debian.org/collab-maint/ltrace.git    git://github.com/sparkleholic/ltrace.git \n \
+    ${DEBIAN_MIRROR}                                    http://archive.debian.org/debian/pool/ \n \
 "
 
 # TODO: This probably belongs to the xenclient-oe layer.

--- a/templates/stable-9/bblayers.conf
+++ b/templates/stable-9/bblayers.conf
@@ -1,0 +1,22 @@
+# LAYER_CONF_VERSION is increased each time conf/bblayers.conf changes
+# incompatibly
+
+LCONF_VERSION = "7"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+BBLAYERS ?= " \
+  ${LAYERS_DIR}/openembedded-core/meta \
+  ${LAYERS_DIR}/meta-openembedded/meta-oe \
+  ${LAYERS_DIR}/meta-openembedded/meta-python \
+  ${LAYERS_DIR}/meta-openembedded/meta-networking \
+  ${LAYERS_DIR}/meta-openembedded/meta-gnome \
+  ${LAYERS_DIR}/meta-openembedded/meta-xfce \
+  ${LAYERS_DIR}/meta-intel \
+  ${LAYERS_DIR}/meta-java \
+  ${LAYERS_DIR}/meta-selinux \
+  ${LAYERS_DIR}/xenclient-oe \
+  ${LAYERS_DIR}/meta-openxt-ocaml-platform \
+  ${LAYERS_DIR}/meta-openxt-haskell-platform \
+  ${LAYERS_DIR}/meta-virtualization \
+  "

--- a/templates/stable-9/build-manifest
+++ b/templates/stable-9/build-manifest
@@ -1,0 +1,12 @@
+# Format:
+# <MACHINE> <target-image-recipe>
+#
+xenclient-dom0 xenclient-initramfs-image
+openxt-installer xenclient-installer-image
+openxt-installer xenclient-installer-part2-image
+upgrade-compat xenclient-upgrade-compat-image
+xenclient-stubdomain xenclient-stubdomain-initramfs-image
+xenclient-dom0 xenclient-dom0-image
+xenclient-uivm xenclient-uivm-image
+xenclient-ndvm xenclient-ndvm-image
+xenclient-syncvm xenclient-syncvm-image

--- a/templates/stable-9/images-manifest
+++ b/templates/stable-9/images-manifest
@@ -1,0 +1,15 @@
+# Format:
+# <MACHINE> <image-id> <source-label> <image-type> <destination-label> <mount-point>
+# MACHINE: Machine name as seen by Bitbake/OE
+# image-id: Image identifier, used in XC-PACKAGES metadata.
+# source-label: Label used to name the built image by Bitbake, usually the name of the recipe that built the image.
+# image-type: The format used for this image.
+# destination-label: Label used to name the image in the destination repository hierarchy (usually <image-id>-rootfs).
+# mount-point: Mount point of the image when deployed on a target.
+#
+openxt-installer control xenclient-installer-part2-image tar.bz2 control /
+upgrade-compat upgrade-compat xenclient-upgrade-compat-image ext3.gz upgrade-compat-rootfs /
+xenclient-dom0 dom0 xenclient-dom0-image ext3.gz dom0-rootfs /
+xenclient-uivm uivm xenclient-uivm-image ext3.vhd.gz uivm-rootfs /storage/uivm
+xenclient-ndvm ndvm xenclient-ndvm-image ext3.disk.vhd.gz ndvm-rootfs /storage/ndvm
+xenclient-syncvm syncvm xenclient-syncvm-image ext3.vhd.gz syncvm-rootfs /storage/syncvm

--- a/templates/stable-9/local.conf
+++ b/templates/stable-9/local.conf
@@ -1,0 +1,99 @@
+# CONF_VERSION is increased each time conf/ changes incompatibly
+CONF_VERSION = "1"
+
+# Removes source after build.
+#INHERIT += "rm_work"
+#RM_WORK_EXCLUDE += ""
+
+# Don't generate the mirror tarball for SCM repos, the snapshot is enough
+BB_GENERATE_MIRROR_TARBALLS = "0"
+
+#
+# Parallelism Options
+#
+# These two options control how much parallelism BitBake should use.
+# The first option determines how many tasks bitbake should run in parallel:
+# Default to setting automatically based on cpu count
+BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"
+#
+# The second option controls how many processes make should run in parallel
+# when running compile tasks:
+# Default to setting automatically based on cpu count
+PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
+
+
+# Detailed build performance log data in tmp/buildstats.
+#INHERIT += "buildstats"
+
+#
+# Shared-state files from other locations
+#
+# Shared state files are prebuilt cache data objects which can used to
+# accelerate build time. This variable can be used to configure the system to
+# search other mirror locations for these objects before it builds the data
+# itself.
+#
+# This can be a filesystem directory, or a remote url such as http or ftp.
+# These would contain the sstate-cache results from previous builds (possibly
+# from other machines). This variable works like fetcher MIRRORS/PREMIRRORS
+# and points to the cache locations to check for the shared objects.
+#SSTATE_MIRRORS ?= "\
+#file://.* http://someserver.tld/share/sstate/ \n \
+#file://.* file:///some/local/dir/sstate/"
+
+#SSTATE_MIRRORS ?= "\
+#file://.* http://dominion.thruhere.net/angstrom/sstate-mirror/ \n "
+
+SSTATE_DUPWHITELIST += "${DEPLOY_DIR}/licences"
+
+# enable PR service on build machine itself its good for a case when this is
+# the only builder generating the feeds
+#
+PRSERV_HOST = "localhost:0"
+
+# Common URL translations.
+MIRRORS += " \
+    http://code.coreboot.org/p/seabios/downloads/.*     https://www.seabios.org/downloads/ \n \
+    http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
+    git://anonscm.debian.org/collab-maint/ltrace.git    git://github.com/sparkleholic/ltrace.git \n \
+"
+
+# TODO: This probably belongs to the xenclient-oe layer.
+REPO_PROD_CACERT="${OPENXT_CERTS_DIR}/prod-cacert.pem"
+REPO_DEV_CACERT="${OPENXT_CERTS_DIR}/dev-cacert.pem"
+REPO_DEV_SIGNING_CERT="${OPENXT_CERTS_DIR}/dev-cacert.pem"
+REPO_DEV_SIGNING_DEV="${OPENXT_CERTS_DIR}/dev-cakey.pem"
+
+# If ENABLE_BINARY_LOCALE_GENERATION is set to "1", you can limit locales
+# generated to the list provided by GLIBC_GENERATE_LOCALES. This is huge
+# time-savior for developmental builds.
+ENABLE_BINARY_LOCALE_GENERATION = "1"
+# Specifies the list of GLIBC locales to generate to save some build time.
+# http://www.yoctoproject.org/docs/current/ref-manual/ref-manual.html#var-GLIBC_GENERATE_LOCALES
+GLIBC_GENERATE_LOCALES += " \
+    de_DE.UTF-8 \
+    en_US.UTF-8 \
+    en_GB.UTF-8 \
+    es_ES.UTF-8 \
+    fr_FR.UTF-8 \
+    ja_JP.UTF-8 \
+    zh_CN.UTF-8 \
+"
+
+# Should be changed for remote feed.
+XENCLIENT_PACKAGE_FEED_URI ?= "file:///storage/ipk"
+
+require openxt.conf
+# xenclient-feed-configs. It requires a bunch of things:
+XENCLIENT_BUILD = "${OPENXT_BUILD_ID}"
+XENCLIENT_BUILD_BRANCH = "${OPENXT_BUILD_BRANCH}"
+XENCLIENT_RELEASE = "${OPENXT_RELEASE}"
+XENCLIENT_VERSION = "${OPENXT_VERSION}"
+include openxt-build-date.conf
+XENCLIENT_BUILD_DATE = "${OPENXT_BUILD_DATE}"
+
+# OpenXT: Set SELinux enforcing (Debug)
+DEFAULT_ENFORCING = "permissive"
+
+# OpenXT: Enable debugging tweaks.
+EXTRA_IMAGE_FEATURES += "debug-tweaks"

--- a/templates/stable-9/openxt.conf
+++ b/templates/stable-9/openxt.conf
@@ -1,0 +1,12 @@
+# OpenXT build ID.
+# Numeral: incremental, starting from the given number.
+OPENXT_BUILD_ID="0"
+# OpenXT version number. This will influence the upgrade path.
+OPENXT_VERSION="9.0.0"
+# Name Refering to the release (purely cosmetic).
+# https://randomword.com/
+OPENXT_RELEASE="gabion"
+# List of OpenXT versions that can be upgraded to this one (${OPENXT_VERSION}).
+OPENXT_UPGRADEABLE_RELEASES="8.0.0 8.0.1 8.0.2 9.0.0"
+# OpenXT branch name.
+OPENXT_BUILD_BRANCH="stable-9"


### PR DESCRIPTION
The last commit in here is https://github.com/apertussolutions/bordel/commit/e2d1929223dbcbf17cfeb8e50c8a993a8b4d7efe
... which corresponds to: https://github.com/apertussolutions/openxt-manifest/commit/539769016a5625a406b8a4d9ea6d77eafa26e720

This is the git format-patch since then, excluding changes to the manifests that stay in https://github.com/apertussolutions/openxt-manifest.