### PR TITLE
Misc fixes for docker builds

### DIFF
--- a/Dockerfiles/openxt-oe64
+++ b/Dockerfiles/openxt-oe64
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -yq \
         help2man make gcc build-essential g++ desktop-file-utils chrpath cpio \
         screen bash-completion python3 iputils-ping guilt iasl quilt bin86 \
         bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip vim \
-        sudo rpm curl libncurses5-dev libelf-dev xorriso \
+        sudo rpm curl libncurses5-dev libelf-dev xorriso libc6-dev-i386 \
         mtools dosfstools file byobu man ca-certificates locales && \
         rm -rf /var/lib/apt-lists/* && \
         echo "dash dash/sh boolean false" | debconf-set-selections && \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# bordel
+
+Helper scripts to manage, build, and package OpenXT builds.
+
+## Setting up a Docker container
+
+NOTE: these instructions assume that you already have a basic build tree set up.
+Follow the Quick Start instructions at https://github.com/apertussolutions/openxt-manifest/
+to set this up.
+
+- Use `./bordel docker list` and note the desired Dockerfile name.
+- Run `./bordel docker create {my_container_name} {Dockerfile_name}` to create the container.
+
+## Building OpenXT with Docker
+
+- First, the build must be configured with `./bordel config [-t template_name] [-b branch]`.
+    * The available template names can be found in `./templates` (the template names match the
+      directory names in this dir).
+    * You can optionally provide a build id using `./bordel -i BUILD_ID config ...`; the default
+      build id is YYMMDD, today's date. Note that this build id must be passed in for the rest
+      of the steps if you elect to use your own.
+- Next, generate your certs with `./bordel [-i BUILD_ID] certs`.
+- To run the full build, run `./bordel [-i BUILD_ID] docker build`.
+- You can optionally run partial build steps manually from inside the container:
+    * Use `./bordel docker enter {my_container_name} [user]` to enter the container as user [user].
+      The default user is `build`.
+    * Navigate to `/home/<user>/openxt/<build-BUILD_ID>` to access your build tree.
+    * Source the build_env file to get access to necessary OE variables (`. build_env`)
+    * Build a single package by running `MACHINE=<machine_name> bitbake <package_name>`
+    * You can run the full build if desired by running `~/openxt/openxt/bordel [-i BUILD_ID] build`

--- a/cmds/build
+++ b/cmds/build
@@ -17,6 +17,9 @@ build_need_conf() { return 0; }
 build_main() {
     local mode=$1
 
+    # Source build_env to get access to necessary OE variables.
+    . "${TOP}/${BUILD_DIR}/build_env"
+
     # Overwrite the build timestamp.
     echo "OPENXT_BUILD_DATE=\"$(date '+%T %D')\"" > ${CONF_DIR}/openxt-build-date.conf
     while read l ; do

--- a/cmds/docker
+++ b/cmds/docker
@@ -60,7 +60,7 @@ docker_build() {
         -v "${HOME}/.gitconfig:/home/${user}/.gitconfig" \
         -v "${HOME}/.repoconfig:/home/${user}/.repoconfig" \
         -v "${HOME}/.repo_.gitconfig.json:/home/${user}/.repo_.gitconfig.json" \
-        "${name}" "/home/${user}/openxt/bin/bordel" "build" "-i ${BUILD_ID}"
+        "${name}" "/home/${user}/openxt/openxt/bordel/bordel" "build" "-i ${BUILD_ID}"
 }
 
 # Usage: docker_usage
@@ -78,8 +78,8 @@ docker_usage() {
 docker_need_conf() { return 1; }
 
 docker_main() {
-    local manifest_dir="${TOP}/.repo/manifests"
-    local dockerfiles="${manifest_dir}/Dockerfiles"
+    local bordel_dir="${TOP}/openxt/bordel"
+    local dockerfiles="${bordel_dir}/Dockerfiles"
 
     command_sane "docker" "docker-ce"
     if [ ! $? ]; then


### PR DESCRIPTION
Docker builds are working with the following changes. The only one I'm not 100% about is the build_env change; I wasn't able to find where it's supposed to be used, so I source it manually if the user uses the build command.