### PR TITLE
build: Return error-code when build fails.

### DIFF
--- a/cmds/build
+++ b/cmds/build
@@ -36,7 +36,7 @@ build_main() {
         fi
         if ! MACHINE="${machine}" bitbake "${image}" ; then
             echo "MACHINE="${machine}" bitbake \"${image}\" failed." >&2
-            break
+            return 1
         fi
 
     done < "${CONF_DIR}/build-manifest"


### PR DESCRIPTION
The command wrapper will not fail otherwise which prevents from chaining
commands, e.g:
`bordel build && bordel deploy iso`