### PR TITLE
config: Add --default to usage.

### DIFF
--- a/cmds/config
+++ b/cmds/config
@@ -126,6 +126,7 @@ Deployment command:
     -t: template name used for OE build config files temlate, default is the default
     -s: select an external sstate directory to use, default is per build_id sstate
     -b: branch to tag/use for the OpenXT repositories, default is build
+    --default: create the 'build' symlink to make this build directory the default one (see bordel -i).
 EOF
 }
 


### PR DESCRIPTION
`--default` is likely to be desired, even though it can be created outside this script. Add the documentation to make the option more explicit.