### PR TITLE
pre-zeus: Add build template

### DIFF
--- a/templates/pre-zeus/bblayers.conf
+++ b/templates/pre-zeus/bblayers.conf
@@ -1,0 +1,22 @@
+# LAYER_CONF_VERSION is increased each time conf/bblayers.conf changes
+# incompatibly
+
+LCONF_VERSION = "7"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+BBLAYERS ?= " \
+  ${LAYERS_DIR}/openembedded-core/meta \
+  ${LAYERS_DIR}/meta-openembedded/meta-oe \
+  ${LAYERS_DIR}/meta-openembedded/meta-python \
+  ${LAYERS_DIR}/meta-openembedded/meta-networking \
+  ${LAYERS_DIR}/meta-openembedded/meta-gnome \
+  ${LAYERS_DIR}/meta-openembedded/meta-xfce \
+  ${LAYERS_DIR}/meta-intel \
+  ${LAYERS_DIR}/meta-java \
+  ${LAYERS_DIR}/meta-selinux \
+  ${LAYERS_DIR}/xenclient-oe \
+  ${LAYERS_DIR}/meta-openxt-ocaml-platform \
+  ${LAYERS_DIR}/meta-openxt-haskell-platform \
+  ${LAYERS_DIR}/meta-virtualization \
+  "

--- a/templates/pre-zeus/build-manifest
+++ b/templates/pre-zeus/build-manifest
@@ -1,0 +1,11 @@
+# Format:
+# <MACHINE> <target-image-recipe>
+#
+xenclient-dom0 xenclient-initramfs-image
+openxt-installer xenclient-installer-image
+openxt-installer xenclient-installer-part2-image
+xenclient-stubdomain xenclient-stubdomain-initramfs-image
+xenclient-dom0 xenclient-dom0-image
+xenclient-uivm xenclient-uivm-image
+xenclient-ndvm xenclient-ndvm-image
+xenclient-syncvm xenclient-syncvm-image

--- a/templates/pre-zeus/images-manifest
+++ b/templates/pre-zeus/images-manifest
@@ -1,0 +1,14 @@
+# Format:
+# <MACHINE> <image-id> <source-label> <image-type> <destination-label> <mount-point>
+# MACHINE: Machine name as seen by Bitbake/OE
+# image-id: Image identifier, used in XC-PACKAGES metadata.
+# source-label: Label used to name the built image by Bitbake, usually the name of the recipe that built the image.
+# image-type: The format used for this image.
+# destination-label: Label used to name the image in the destination repository hierarchy (usually <image-id>-rootfs).
+# mount-point: Mount point of the image when deployed on a target.
+#
+openxt-installer control xenclient-installer-part2-image tar.bz2 control /
+xenclient-dom0 dom0 xenclient-dom0-image ext3.gz dom0-rootfs /
+xenclient-uivm uivm xenclient-uivm-image ext3.vhd.gz uivm-rootfs /storage/uivm
+xenclient-ndvm ndvm xenclient-ndvm-image ext3.disk.vhd.gz ndvm-rootfs /storage/ndvm
+xenclient-syncvm syncvm xenclient-syncvm-image ext3.vhd.gz syncvm-rootfs /storage/syncvm

--- a/templates/pre-zeus/local.conf
+++ b/templates/pre-zeus/local.conf
@@ -1,0 +1,99 @@
+# CONF_VERSION is increased each time conf/ changes incompatibly
+CONF_VERSION = "1"
+
+# Removes source after build.
+#INHERIT += "rm_work"
+#RM_WORK_EXCLUDE += ""
+
+# Don't generate the mirror tarball for SCM repos, the snapshot is enough
+BB_GENERATE_MIRROR_TARBALLS = "0"
+
+#
+# Parallelism Options
+#
+# These two options control how much parallelism BitBake should use.
+# The first option determines how many tasks bitbake should run in parallel:
+# Default to setting automatically based on cpu count
+BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"
+#
+# The second option controls how many processes make should run in parallel
+# when running compile tasks:
+# Default to setting automatically based on cpu count
+PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
+
+
+# Detailed build performance log data in tmp/buildstats.
+#INHERIT += "buildstats"
+
+#
+# Shared-state files from other locations
+#
+# Shared state files are prebuilt cache data objects which can used to
+# accelerate build time. This variable can be used to configure the system to
+# search other mirror locations for these objects before it builds the data
+# itself.
+#
+# This can be a filesystem directory, or a remote url such as http or ftp.
+# These would contain the sstate-cache results from previous builds (possibly
+# from other machines). This variable works like fetcher MIRRORS/PREMIRRORS
+# and points to the cache locations to check for the shared objects.
+#SSTATE_MIRRORS ?= "\
+#file://.* http://someserver.tld/share/sstate/ \n \
+#file://.* file:///some/local/dir/sstate/"
+
+#SSTATE_MIRRORS ?= "\
+#file://.* http://dominion.thruhere.net/angstrom/sstate-mirror/ \n "
+
+SSTATE_DUPWHITELIST += "${DEPLOY_DIR}/licences"
+
+# enable PR service on build machine itself its good for a case when this is
+# the only builder generating the feeds
+#
+PRSERV_HOST = "localhost:0"
+
+# Common URL translations.
+MIRRORS += " \
+    http://code.coreboot.org/p/seabios/downloads/.*     https://www.seabios.org/downloads/ \n \
+    http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
+    git://anonscm.debian.org/collab-maint/ltrace.git    git://github.com/sparkleholic/ltrace.git \n \
+"
+
+# TODO: This probably belongs to the xenclient-oe layer.
+REPO_PROD_CACERT="${OPENXT_CERTS_DIR}/prod-cacert.pem"
+REPO_DEV_CACERT="${OPENXT_CERTS_DIR}/dev-cacert.pem"
+REPO_DEV_SIGNING_CERT="${OPENXT_CERTS_DIR}/dev-cacert.pem"
+REPO_DEV_SIGNING_DEV="${OPENXT_CERTS_DIR}/dev-cakey.pem"
+
+# If ENABLE_BINARY_LOCALE_GENERATION is set to "1", you can limit locales
+# generated to the list provided by GLIBC_GENERATE_LOCALES. This is huge
+# time-savior for developmental builds.
+ENABLE_BINARY_LOCALE_GENERATION = "1"
+# Specifies the list of GLIBC locales to generate to save some build time.
+# http://www.yoctoproject.org/docs/current/ref-manual/ref-manual.html#var-GLIBC_GENERATE_LOCALES
+GLIBC_GENERATE_LOCALES += " \
+    de_DE.UTF-8 \
+    en_US.UTF-8 \
+    en_GB.UTF-8 \
+    es_ES.UTF-8 \
+    fr_FR.UTF-8 \
+    ja_JP.UTF-8 \
+    zh_CN.UTF-8 \
+"
+
+# Should be changed for remote feed.
+XENCLIENT_PACKAGE_FEED_URI ?= "file:///storage/ipk"
+
+require openxt.conf
+# xenclient-feed-configs. It requires a bunch of things:
+XENCLIENT_BUILD = "${OPENXT_BUILD_ID}"
+XENCLIENT_BUILD_BRANCH = "${OPENXT_BUILD_BRANCH}"
+XENCLIENT_RELEASE = "${OPENXT_RELEASE}"
+XENCLIENT_VERSION = "${OPENXT_VERSION}"
+include openxt-build-date.conf
+XENCLIENT_BUILD_DATE = "${OPENXT_BUILD_DATE}"
+
+# OpenXT: Set SELinux enforcing (Debug)
+DEFAULT_ENFORCING = "permissive"
+
+# OpenXT: Enable debugging tweaks.
+EXTRA_IMAGE_FEATURES += "debug-tweaks"

--- a/templates/pre-zeus/openxt.conf
+++ b/templates/pre-zeus/openxt.conf
@@ -1,0 +1,12 @@
+# OpenXT build ID.
+# Numeral: incremental, starting from the given number.
+OPENXT_BUILD_ID="0"
+# OpenXT version number. This will influence the upgrade path.
+OPENXT_VERSION="10.0.0"
+# Name Refering to the release (purely cosmetic).
+# https://randomword.com/
+OPENXT_RELEASE="pre-zeus"
+# List of OpenXT versions that can be upgraded to this one (${OPENXT_VERSION}).
+OPENXT_UPGRADEABLE_RELEASES="9.0.0 9.0.1 9.0.2"
+# OpenXT branch name.
+OPENXT_BUILD_BRANCH="master"


### PR DESCRIPTION
Create a build template to build OpenXT repository using last notorious revisions before the Zeus upgrade.

pre-zeus manifest: https://github.com/apertussolutions/openxt-manifest/pull/31