### PR TITLE
master: template post Zeus upgrade

### DIFF
--- a/templates/master/bblayers.conf
+++ b/templates/master/bblayers.conf
@@ -11,6 +11,8 @@ BBLAYERS ?= " \
   ${LAYERS_DIR}/meta-openembedded/meta-python \
   ${LAYERS_DIR}/meta-openembedded/meta-networking \
   ${LAYERS_DIR}/meta-openembedded/meta-gnome \
+  ${LAYERS_DIR}/meta-openembedded/meta-multimedia \
+  ${LAYERS_DIR}/meta-openembedded/meta-filesystems \
   ${LAYERS_DIR}/meta-openembedded/meta-xfce \
   ${LAYERS_DIR}/meta-intel \
   ${LAYERS_DIR}/meta-java \

--- a/templates/master/local.conf
+++ b/templates/master/local.conf
@@ -21,6 +21,11 @@ BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"
 # Default to setting automatically based on cpu count
 PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 
+# webkitgtk can be ravenous when building, avoid triggering OOM-killer.
+# It looks like cpu_count / 2 is working in most places.
+# If building webkitgtk triggers the OOM-killer on your platform, try to
+# uncomment the following line and adjust the value.
+#PARALLEL_MAKE_pn-webkitgtk = "-j `expr \( ${@oe.utils.cpu_count()} / 2 \)`"
 
 # Detailed build performance log data in tmp/buildstats.
 #INHERIT += "buildstats"

--- a/templates/master/openxt.conf
+++ b/templates/master/openxt.conf
@@ -7,6 +7,6 @@ OPENXT_VERSION="10.0.0"
 # https://randomword.com/
 OPENXT_RELEASE="agrypnotic"
 # List of OpenXT versions that can be upgraded to this one (${OPENXT_VERSION}).
-OPENXT_UPGRADEABLE_RELEASES="8.0.0 8.0.1 8.0.2 9.0.0"
+OPENXT_UPGRADEABLE_RELEASES="9.0.0 9.0.1 9.0.2"
 # OpenXT branch name.
 OPENXT_BUILD_BRANCH="master"


### PR DESCRIPTION
- Add new layers to bblayers.conf (required by OE re-arrangement and
dependencies).
- Remove 8.0.x from the upgrade path, upgrade is only supported from one
major release to the next (master being 10.0.x-pre in this case).
- Add proposed work-around for webkitgtk build triggering the OOM-killer
on some configuration (8G or less RAM).