### PR TITLE
build: changing the build manifest format

### DIFF
--- a/cmds/build
+++ b/cmds/build
@@ -28,14 +28,14 @@ build_main() {
         fi
 
         local entry=(${l})
-        local machine="${entry[0]}"
-        local image="${entry[1]}"
+        local image="${entry[0]}"
+        local env="${entry[@]:1}"
 
         if [ "${mode}" = "clean" ]; then
-            MACHINE="${machine}" bitbake -c cleanall "${image}"
+            eval ${env} bitbake -c cleanall "${image}"
         fi
-        if ! MACHINE="${machine}" bitbake "${image}" ; then
-            echo "MACHINE="${machine}" bitbake \"${image}\" failed." >&2
+        if ! eval ${env} bitbake "${image}" ; then
+            echo "${env} bitbake \"${image}\" failed." >&2
             return 1
         fi
 

--- a/templates/master/build-manifest
+++ b/templates/master/build-manifest
@@ -1,11 +1,11 @@
 # Format:
-# <MACHINE> <target-image-recipe>
+# <target-image-recipe> [ENV VARS]*
 #
-xenclient-dom0 xenclient-initramfs-image
-openxt-installer xenclient-installer-image
-openxt-installer xenclient-installer-part2-image
-xenclient-stubdomain xenclient-stubdomain-initramfs-image
-xenclient-dom0 xenclient-dom0-image
-xenclient-uivm xenclient-uivm-image
-xenclient-ndvm xenclient-ndvm-image
-xenclient-syncvm xenclient-syncvm-image
+xenclient-initramfs-image MACHINE=xenclient-dom0
+xenclient-installer-image MACHINE=openxt-installer
+xenclient-installer-part2-image MACHINE=openxt-installer
+xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
+xenclient-dom0-image MACHINE=xenclient-dom0
+xenclient-uivm-image MACHINE=xenclient-uivm
+xenclient-ndvm-image MACHINE=xenclient-ndvm
+xenclient-syncvm-image MACHINE=xenclient-syncvm

--- a/templates/pre-zeus/build-manifest
+++ b/templates/pre-zeus/build-manifest
@@ -1,11 +1,11 @@
 # Format:
-# <MACHINE> <target-image-recipe>
+# <target-image-recipe> [ENV VARS]*
 #
-xenclient-dom0 xenclient-initramfs-image
-openxt-installer xenclient-installer-image
-openxt-installer xenclient-installer-part2-image
-xenclient-stubdomain xenclient-stubdomain-initramfs-image
-xenclient-dom0 xenclient-dom0-image
-xenclient-uivm xenclient-uivm-image
-xenclient-ndvm xenclient-ndvm-image
-xenclient-syncvm xenclient-syncvm-image
+xenclient-initramfs-image MACHINE=xenclient-dom0
+xenclient-installer-image MACHINE=openxt-installer
+xenclient-installer-part2-image MACHINE=openxt-installer
+xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
+xenclient-dom0-image MACHINE=xenclient-dom0
+xenclient-uivm-image MACHINE=xenclient-uivm
+xenclient-ndvm-image MACHINE=xenclient-ndvm
+xenclient-syncvm-image MACHINE=xenclient-syncvm

--- a/templates/stable-6/build-manifest
+++ b/templates/stable-6/build-manifest
@@ -1,5 +1,5 @@
 # Format:
-# <MACHINE> <target-image-recipe>
+# <target-image-recipe> [ENV VARS]*
 #
 xenclient-dom0:xenclient-initramfs-image
 xenclient-dom0:xenclient-installer-image

--- a/templates/stable-7/build-manifest
+++ b/templates/stable-7/build-manifest
@@ -1,11 +1,11 @@
 # Format:
-# <MACHINE> <target-image-recipe>
+# <target-image-recipe> [ENV VARS]*
 #
-xenclient-dom0 xenclient-initramfs-image
-xenclient-dom0 xenclient-installer-image
-xenclient-dom0 xenclient-installer-part2-image
-xenclient-stubdomain xenclient-stubdomain-initramfs-image
-xenclient-dom0 xenclient-dom0-image
-xenclient-uivm xenclient-uivm-image
-xenclient-ndvm xenclient-ndvm-image
-xenclient-syncvm xenclient-syncvm-image
+xenclient-initramfs-image MACHINE=xenclient-dom0
+xenclient-installer-image MACHINE=xenclient-dom0
+xenclient-installer-part2-image MACHINE=xenclient-dom0
+xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
+xenclient-dom0-image MACHINE=xenclient-dom0
+xenclient-uivm-image MACHINE=xenclient-uivm
+xenclient-ndvm-image MACHINE=xenclient-ndvm
+xenclient-syncvm-image MACHINE=xenclient-syncvm

--- a/templates/stable-8/build-manifest
+++ b/templates/stable-8/build-manifest
@@ -1,11 +1,11 @@
 # Format:
-# <MACHINE> <target-image-recipe>
+# <target-image-recipe> [ENV VARS]*
 #
-xenclient-dom0 xenclient-initramfs-image
-openxt-installer xenclient-installer-image
-openxt-installer xenclient-installer-part2-image
-xenclient-stubdomain xenclient-stubdomain-initramfs-image
-xenclient-dom0 xenclient-dom0-image
-xenclient-uivm xenclient-uivm-image
-xenclient-ndvm xenclient-ndvm-image
-xenclient-syncvm xenclient-syncvm-image
+xenclient-initramfs-image MACHINE=xenclient-dom0
+xenclient-installer-image MACHINE=openxt-installer
+xenclient-installer-part2-image MACHINE=openxt-installer
+xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
+xenclient-dom0-image MACHINE=xenclient-dom0
+xenclient-uivm-image MACHINE=xenclient-uivm
+xenclient-ndvm-image MACHINE=xenclient-ndvm
+xenclient-syncvm-image MACHINE=xenclient-syncvm

--- a/templates/stable-9/build-manifest
+++ b/templates/stable-9/build-manifest
@@ -1,12 +1,12 @@
 # Format:
-# <MACHINE> <target-image-recipe>
+# <target-image-recipe> [ENV VARS]*
 #
-xenclient-dom0 xenclient-initramfs-image
-openxt-installer xenclient-installer-image
-openxt-installer xenclient-installer-part2-image
-upgrade-compat xenclient-upgrade-compat-image
-xenclient-stubdomain xenclient-stubdomain-initramfs-image
-xenclient-dom0 xenclient-dom0-image
-xenclient-uivm xenclient-uivm-image
-xenclient-ndvm xenclient-ndvm-image
-xenclient-syncvm xenclient-syncvm-image
+xenclient-initramfs-image MACHINE=xenclient-dom0
+xenclient-installer-image MACHINE=openxt-installer
+xenclient-installer-part2-image MACHINE=openxt-installer
+xenclient-upgrade-compat-image MACHINE=upgrade-compat
+xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
+xenclient-dom0-image MACHINE=xenclient-dom0
+xenclient-uivm-image MACHINE=xenclient-uivm
+xenclient-ndvm-image MACHINE=xenclient-ndvm
+xenclient-syncvm-image MACHINE=xenclient-syncvm

--- a/templates/sumo/build-manifest
+++ b/templates/sumo/build-manifest
@@ -1,11 +1,11 @@
 # Format:
-# <MACHINE> <target-image-recipe>
+# <target-image-recipe> [ENV VARS]*
 #
-xenclient-dom0 xenclient-initramfs-image
-openxt-installer xenclient-installer-image
-openxt-installer xenclient-installer-part2-image
-xenclient-stubdomain xenclient-stubdomain-initramfs-image
-xenclient-dom0 xenclient-dom0-image
-xenclient-uivm xenclient-uivm-image
-xenclient-ndvm xenclient-ndvm-image
-xenclient-syncvm xenclient-syncvm-image
+xenclient-initramfs-image MACHINE=xenclient-dom0
+xenclient-installer-image MACHINE=openxt-installer
+xenclient-installer-part2-image MACHINE=openxt-installer
+xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
+xenclient-dom0-image MACHINE=xenclient-dom0
+xenclient-uivm-image MACHINE=xenclient-uivm
+xenclient-ndvm-image MACHINE=xenclient-ndvm
+xenclient-syncvm-image MACHINE=xenclient-syncvm


### PR DESCRIPTION
This changes the build manifest to be a list of image recipes followed
by zero or more environment variables to override for the build.
Typical environment variables are the MACHINE and DISTRO bitbake
variables.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>