### PR TITLE
stage: Use mkfs.fat instead of mkfs wrapper

### DIFF
--- a/cmds/stage
+++ b/cmds/stage
@@ -235,7 +235,7 @@ stage_iso() {
     rm -f ${efi_img}
     mkdir -p "$(dirname "${efi_img}")"
     dd if=/dev/zero bs=1M count=5 of="${efi_img}"
-    /sbin/mkfs -t fat "${efi_img}"
+    /sbin/mkfs.fat "${efi_img}"
     mmd -i ${efi_img} EFI
     mmd -i ${efi_img} EFI/BOOT
 


### PR DESCRIPTION
/sbin/mkfs requires /sbin to be in the PATH of the user running it to find the subcommands (e.g, mkfs.fat) correctly. This is not the case for a regular user, yet the EFI ESP for the iso installer can, arguably should, be created without root permissions.

Use /sbin/mkfs.fat directly to work-around the above limitation without having to twiddle with the user's PATH.