### PR TITLE
version: Use OPENXT_RELEASE appropriately

### DIFF
--- a/cmds/deploy
+++ b/cmds/deploy
@@ -19,7 +19,7 @@ deploy_iso_legacy() {
         -no-emul-boot \
         -boot-load-size 4 \
         -boot-info-table \
-        -r -J -l -V "OpenXT ${OPENXT_VERSION} installer." \
+        -r -J -l -V "OpenXT ${OPENXT_RELEASE} installer." \
         "${STAGING_DIR}/iso" \
         "${STAGING_DIR}/repository"
     if [ $? -ne 0 ]; then
@@ -68,7 +68,7 @@ deploy_iso() {
         -r \
         -J \
         -l \
-        -V "OpenXT ${OPENXT_VERSION} installer." \
+        -V "OpenXT ${OPENXT_RELEASE} installer." \
         -f \
         -quiet \
         "${STAGING_DIR}/iso" \

--- a/functions
+++ b/functions
@@ -22,10 +22,10 @@ check_cmd_version() {
     local cmd="$1"
 
     # Ignore development/hacked versions.
-    if [ "${OPENXT_VERSION}" = "0.0.0" -o -z "${OPENXT_VERSION}" ]; then
+    if [ "${OPENXT_RELEASE}" = "0.0.0" -o -z "${OPENXT_RELEASE}" ]; then
         return 0
     fi
-    if [ "${OPENXT_VERSION%%.*}" -ge "8" ]; then
+    if [ "${OPENXT_RELEASE%%.*}" -ge "8" ]; then
         case "${cmd}" in
             *"-old")
                 echo "\`${cmd}' is no longer supported with OpenXT 8 and later versions. See \`${cmd%%-old}' command replacement." >&2


### PR DESCRIPTION
OPENXT_VERSION and OPENXT_RELEASE were inverted for the longest time.
Some functions worked on the wrong assumption that OPENXT_VERSION was
the numeral release number. Switch to OPENXT_VERSION where appropriate.