### PR TITLE
config: Create mirror link

### DIFF
--- a/cmds/config
+++ b/cmds/config
@@ -190,6 +190,10 @@ config_main() {
         exit 1
     fi
 
+    pushd "${TOP}" > /dev/null
+    ln -sf .repo/projects/openxt mirror
+    popd > /dev/null 2>&1
+
     config_generate_dir "${sstate_dir}"
     if [ "${default}" == "true" ]; then
         ln -sf "${TOP}/${BUILD_DIR}" "${TOP}/build"


### PR DESCRIPTION
'repo init' will fail with the manifest entry:
 <linkfile dest="mirror" src="../../.repo/projects/openxt/"/>
since .repo/projects does not exist.
Recent versions will only bare-clone the repositories in .repo/projects
after 'repo sync'.

#### Depends on:
- https://github.com/apertussolutions/openxt-manifest/pull/36