### PR TITLE
bordel: return error code in call_cmd

### DIFF
--- a/bordel
+++ b/bordel
@@ -50,6 +50,11 @@ fi
 command="$1"
 shift 1
 
+if ! valid_cmd "${command}"; then
+    echo "Unknown command ${command}." >&2
+    usage 1
+fi
+
 if [ -n "${BUILD_ID}" ]; then
     BUILD_DIR="build-${BUILD_ID}"
 elif [ -e "${TOP}/build" ]; then
@@ -84,11 +89,12 @@ fi
 if [ -d "${TOP}/${BUILD_DIR}" -a "${command}" != "config" ]; then
 	pushd "${TOP}/${BUILD_DIR}" >/dev/null
 fi
+
 call_cmd ${command} $@
 ret=$?
 
 popd > /dev/null 2>&1
 
 if [ $ret -ne 0 ]; then
-       usage 1
+    exit $ret
 fi

--- a/functions
+++ b/functions
@@ -70,15 +70,15 @@ describe_cmds() {
     done
 }
 
+valid_cmd() {
+    local cmd="${1}"
+
+    [ -z "${_CMDS##*${cmd}*}" ]
+}
+
 call_cmd() {
     local cmd=${1}
     shift 1
 
-    if [ -z "${_CMDS##*${cmd}*}" ]; then
-        eval "${cmd}_main $@"
-        return 0
-    else
-        echo "Unknown command ${cmd} attempted to be called/" >&2
-        return 1
-    fi
+    "${cmd}_main" $@
 }


### PR DESCRIPTION
Check for the command before calling ${command}_conf to avoid spurious
error messages and let call_cmd propagate the command error code.