### PR TITLE
Add Debian buster Dockerfile

### DIFF
--- a/Dockerfiles/openxt-buster-oe64
+++ b/Dockerfiles/openxt-buster-oe64
@@ -1,0 +1,58 @@
+FROM multiarch/debian-debootstrap:amd64-buster
+MAINTAINER Daniel P. Smith <dpsmith@apertussolutions.com>
+
+ARG UNAME=build
+ARG UID=1000
+ARG GID=1000
+
+RUN sed -i "/buster-updates/d" /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -yq \
+        openssh-server openssl \
+        sed wget cvs subversion git-core coreutils \
+        unzip texi2html texinfo docbook-utils gawk python-pysqlite2 diffstat \
+        help2man make gcc build-essential g++ desktop-file-utils chrpath cpio \
+        screen bash-completion python3 iputils-ping \
+        guilt iasl quilt bin86 \
+        bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip vim \
+        sudo rpm curl libncurses5-dev libncursesw5 libc6-dev-i386 libelf-dev \
+        xorriso mtools dosfstools \
+        file byobu man ca-certificates locales && \
+        rm -rf /var/lib/apt-lists/* && \
+        echo "dash dash/sh boolean false" | debconf-set-selections && \
+        DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
+# Download the GHC prerequisites from squeeze
+RUN mkdir -p /tmp/ghc-prereq && cd /tmp/ghc-prereq && \
+	wget http://archive.debian.org/debian/pool/main/g/gmp/libgmpxx4ldbl_4.3.2+dfsg-1_amd64.deb && \
+	wget http://archive.debian.org/debian/pool/main/g/gmp/libgmp3c2_4.3.2+dfsg-1_amd64.deb && \
+	wget http://archive.debian.org/debian/pool/main/g/gmp/libgmp3-dev_4.3.2+dfsg-1_amd64.deb && \
+        dpkg -i libgmpxx4ldbl_4.3.2+dfsg-1_amd64.deb libgmp3c2_4.3.2+dfsg-1_amd64.deb \
+		libgmp3-dev_4.3.2+dfsg-1_amd64.deb && \
+        cd /tmp && rm -rf /tmp/ghc-prereq
+
+# Install the required version of GHC
+RUN cd /tmp && \
+	wget https://downloads.haskell.org/~ghc/6.12.3/ghc-6.12.3-x86_64-unknown-linux-n.tar.bz2 && \
+        tar jxf ghc-6.12.3-x86_64-unknown-linux-n.tar.bz2 && \
+        rm ghc-6.12.3-x86_64-unknown-linux-n.tar.bz2 && \
+        cd ghc-6.12.3 && \
+        ./configure --prefix=/usr && \
+        make install && \
+        cd /tmp && rm -rf ghc-6.12.3
+
+# Add "repo" tool (used by many Yocto-based projects)
+RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && \
+        chmod a+x /usr/local/bin/repo
+
+# Symlink for troublesome packages
+RUN ln -s /lib64/ld-linux-x86-64.so.2 /lib/
+
+RUN useradd -Ums /bin/bash -p '""' -G sudo -u $UID $UNAME
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.utf8
+USER $UNAME
+WORKDIR /home/$UNAME
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Zeus needs buster to build, so add a buster Dockerfile.  It's mostly a
copy of the openxt-oe64 Dockerfile with jessie replaced by buster.
With that, add the new package deps for buster as specified in
openxt.git:build-scripts/oe/setup.sh.

The other change is the reformating of the package list to match
newlines from openxt.git:build-scripts/oe/setup.sh.  This aids in
comparing the two to keep them in sync.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>