### PR TITLE
qol: Small fixes for silent failures and warnings.

### DIFF
--- a/cmds/config
+++ b/cmds/config
@@ -21,7 +21,7 @@ config_generate_dir() {
         ln -sf ../sstate-cache
     fi
 
-    for d in layers downloads ccache mirror ${CERTS_DIR}; do
+    for d in layers downloads ccache ${CERTS_DIR}; do
         if [ ! -e "../${d}" ]; then
             mkdir "../${d}"
         fi

--- a/cmds/config
+++ b/cmds/config
@@ -196,7 +196,7 @@ config_main() {
 
     config_generate_dir "${sstate_dir}"
     if [ "${default}" == "true" ]; then
-        ln -sf "${TOP}/${BUILD_DIR}" "${TOP}/build"
+        ln -sfrT "${TOP}/${BUILD_DIR}" "${TOP}/build"
     fi
 
     for f in bblayers.conf local.conf openxt.conf build-manifest images-manifest; do

--- a/cmds/stage
+++ b/cmds/stage
@@ -106,13 +106,14 @@ stage_repository() {
         if [ -z "${l%%#*}" ]; then
             continue
         fi
-        entry=(${l})
-        machine="${entry[0]}"
-        img_id="${entry[1]}"
-        img_src_label="${entry[2]}"
-        img_type="${entry[3]}"
-        img_dst_label="${entry[4]}"
-        img_dst_mnt="${entry[5]}"
+        local entry=(${l})
+        local machine="${entry[0]}"
+        local img_id="${entry[1]}"
+        local img_src_label="${entry[2]}"
+        local img_type="${entry[3]}"
+        local img_dst_label="${entry[4]}"
+        local img_dst_mnt="${entry[5]}"
+        local img_format
 
         case "${img_type}" in
             tar.bz2) img_format="tarbz2";;
@@ -128,8 +129,8 @@ stage_repository() {
             *) img_format="file" ;;
         esac
 
-        img_src_name="${img_src_label}-${machine}.${img_type}"
-        img_dst_name="${img_dst_label}.${img_type}"
+        local img_src_name="${img_src_label}-${machine}.${img_type}"
+        local img_dst_name="${img_dst_label}.${img_type}"
 
         if [ "${img_id}" = "file" ]; then
             img_dst_name="${img_dst_label}.${img_format}"


### PR DESCRIPTION
- `stage_repository()` did not declare its alias variables locally.
- the `build` symlink that is used to define the default build tree is not created correctly when re-configuring.
- `mirror` should not be created by the `config` command as it is a symlink to the repo bare mirrors.