### PR TITLE
Revert "config: do not try to create mirror directory."

### DIFF
--- a/cmds/config
+++ b/cmds/config
@@ -21,7 +21,7 @@ config_generate_dir() {
         ln -sf ../sstate-cache
     fi
 
-    for d in layers downloads ccache ${CERTS_DIR}; do
+    for d in layers downloads ccache mirror ${CERTS_DIR}; do
         if [ ! -e "../${d}" ]; then
             mkdir "../${d}"
         fi


### PR DESCRIPTION
This reverts commit e0975defa56b900ef319145123c168cfeeca5aaa.

This was not the problem described in the commit message and actually breaks the build since the link is now missing in every SRC_URI.