### PR TITLE
config: Add common mirrors to local.conf

### DIFF
--- a/templates/master/local.conf
+++ b/templates/master/local.conf
@@ -61,6 +61,9 @@ MIRRORS += " \
     http://code.coreboot.org/p/seabios/downloads/.*     https://www.seabios.org/downloads/ \n \
     http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
     git://anonscm.debian.org/collab-maint/ltrace.git    git://github.com/sparkleholic/ltrace.git \n \
+    http://v3.sk/.*                                     https://openxt.ainfosec.com/mirror/ \n \
+    https://svwh.dl.sourceforge.net/project/linuxconsole/.*     https://openxt.ainfosec.com/mirror/ \n \
+    https://cgit.freedesktop.org/~airlied/vbetool/.*    https://openxt.ainfosec.com/mirror/ \n \
 "
 
 # TODO: This probably belongs to the xenclient-oe layer.

--- a/templates/stable-8/local.conf
+++ b/templates/stable-8/local.conf
@@ -57,6 +57,9 @@ MIRRORS += " \
     http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
     git://anonscm.debian.org/collab-maint/ltrace.git    git://github.com/sparkleholic/ltrace.git \n \
     ${DEBIAN_MIRROR}                                    http://archive.debian.org/debian/pool/ \n \
+    http://v3.sk/.*                                     https://openxt.ainfosec.com/mirror/ \n \
+    https://svwh.dl.sourceforge.net/project/linuxconsole/.*     https://openxt.ainfosec.com/mirror/ \n \
+    https://cgit.freedesktop.org/~airlied/vbetool/.*    https://openxt.ainfosec.com/mirror/ \n \
 "
 
 # TODO: This probably belongs to the xenclient-oe layer.

--- a/templates/stable-9/local.conf
+++ b/templates/stable-9/local.conf
@@ -56,6 +56,9 @@ MIRRORS += " \
     http://code.coreboot.org/p/seabios/downloads/.*     https://www.seabios.org/downloads/ \n \
     http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
     git://anonscm.debian.org/collab-maint/ltrace.git    git://github.com/sparkleholic/ltrace.git \n \
+    http://v3.sk/.*                                     https://openxt.ainfosec.com/mirror/ \n \
+    https://svwh.dl.sourceforge.net/project/linuxconsole/.*     https://openxt.ainfosec.com/mirror/ \n \
+    https://cgit.freedesktop.org/~airlied/vbetool/.*    https://openxt.ainfosec.com/mirror/ \n \
 "
 
 # TODO: This probably belongs to the xenclient-oe layer.


### PR DESCRIPTION
- dev86 source is mostly 503.
- linuxconsole answers 404 quite often.
- vbetool tarballs are no longer available.