### PR TITLE
templates: build package-index

### DIFF
--- a/templates/master/build-manifest
+++ b/templates/master/build-manifest
@@ -9,3 +9,4 @@ xenclient-dom0-image MACHINE=xenclient-dom0
 xenclient-uivm-image MACHINE=xenclient-uivm
 xenclient-ndvm-image MACHINE=xenclient-ndvm
 xenclient-syncvm-image MACHINE=xenclient-syncvm
+package-index MACHINE=xenclient-dom0

--- a/templates/stable-8/build-manifest
+++ b/templates/stable-8/build-manifest
@@ -9,3 +9,4 @@ xenclient-dom0-image MACHINE=xenclient-dom0
 xenclient-uivm-image MACHINE=xenclient-uivm
 xenclient-ndvm-image MACHINE=xenclient-ndvm
 xenclient-syncvm-image MACHINE=xenclient-syncvm
+package-index MACHINE=xenclient-dom0

--- a/templates/stable-9/build-manifest
+++ b/templates/stable-9/build-manifest
@@ -10,3 +10,4 @@ xenclient-dom0-image MACHINE=xenclient-dom0
 xenclient-uivm-image MACHINE=xenclient-uivm
 xenclient-ndvm-image MACHINE=xenclient-ndvm
 xenclient-syncvm-image MACHINE=xenclient-syncvm
+package-index MACHINE=xenclient-dom0


### PR DESCRIPTION
package-index will generate the package manifest following the images being built. This manifest can then be used by opkg as a feed.