### PR TITLE
config: add --rmwork switch

### DIFF
--- a/cmds/config
+++ b/cmds/config
@@ -35,13 +35,15 @@ config_generate_dir() {
 config_generate_auto() {
     local branch="${1}"
     local forced="${2}"
+    local rmwork="${3}"
+    local auto_conf="${TOP}/${BUILD_DIR}/${CONF_DIR}/auto.conf"
 
-    if [ -e "${TOP}/${BUILD_DIR}/${CONF_DIR}/auto.conf" ] && \
+    if [ -e "${auto_conf}" ] && \
        [ "${forced}" != "true" ]; then
         return
     fi
 
-    cat > "${TOP}/${BUILD_DIR}/${CONF_DIR}/auto.conf" << EOF
+    cat > "${auto_conf}" << EOF
 #
 # Auto-generated configuration
 #
@@ -68,6 +70,10 @@ OPENXT_BUILD_DATE ?= "$(date '+%T %D')"
 # OpenXT: Where To get the signing certificates.
 OPENXT_CERTS_DIR = "\${TOPDIR}/${CERTS_DIR}"
 EOF
+
+    if [ "${rmwork}" = "true" ]; then
+        echo "INHERIT += \"rm_work\"" >> ${auto_conf}
+    fi
 }
 
 config_copy_template() {
@@ -133,6 +139,7 @@ Deployment command:
     -b: branch to tag/use for the OpenXT repositories, default is build
     --default: create the 'build' symlink to make this build directory the default one (see bordel -i).
     --force: overwrite any existing configuration if the build tree was already configured.
+    --rmwork: inherit rm_work.bbclass, deleting temporary workspace.
 EOF
 }
 
@@ -145,8 +152,9 @@ config_main() {
     local sstate_dir=""
     local default="false"
     local forced="false"
+    local rmwork="false"
 
-    options=$(getopt -o t:s:b:h -l default,force -- "$@")
+    options=$(getopt -o t:s:b:h -l default,force,rmwork -- "$@")
     if [ $? -ne 0 ]; then
         config_usage
         exit 1
@@ -177,6 +185,9 @@ config_main() {
         --force)
             forced=true
             ;;
+	--rmwork)
+	    rmwork=true
+	    ;;
         --)
             shift
             break
@@ -205,7 +216,7 @@ config_main() {
             exit 1
         fi
     done
-    config_generate_auto "${branch}" "${forced}"
+    config_generate_auto "${branch}" "${forced}" "${rmwork}"
 
     pushd "${TOP}" >/dev/null
     repo start "${branch}" openxt/*

--- a/templates/stable-9/local.conf
+++ b/templates/stable-9/local.conf
@@ -97,3 +97,22 @@ DEFAULT_ENFORCING = "permissive"
 
 # OpenXT: Enable debugging tweaks.
 EXTRA_IMAGE_FEATURES += "debug-tweaks"
+
+# rm_work had a bug until:
+#   0f537d985b rm_work: Handle race with -inital tasks
+# The fix depends on a change in bitbake, so don't use rm_work for recipes that
+# don't have dependencies on do_build (-initial only?).
+RM_WORK_EXCLUDE += " \
+    glibc-initial \
+    gcc-cross-initial \
+    libgcc-initial \
+    gcc-crosssdk-initial \
+    libgcc-initial \
+    gcc-cross-initial \
+    gcc-crosssdk-initial \
+    cacao-initial-native \
+    ecj-initial-native \
+    jikes-initial-native \
+    classpath-initial-native \
+    jamvm-initial-native \
+"


### PR DESCRIPTION
In some cases, it is desirable to use rm_work.bbclass (e.g, autobuilder). While this can be setup by another configuration file (site.conf), offer a convenience switch to reduce external interactions.

Work-around rm_work for stable-9 as it does not have: 0f537d985b rm_work: Handle race with -inital tasks