### PR TITLE
stage: fix legacy staging

### DIFF
--- a/cmds/stage
+++ b/cmds/stage
@@ -161,7 +161,7 @@ stage_iso() {
     local image_name="xenclient-installer-image-${machine}"
     # Post do_deploy refactoring path (see IMAGE_LINK in xenclient-oe).
     local iso_src_path="${machine}/${image_name}/iso"
-    if [ ! -d "${iso_src_path}" ]; then
+    if [ ! -d "${IMAGES_DIR}/${iso_src_path}" ]; then
         iso_src_path="${machine}/iso"
     fi
 


### PR DESCRIPTION
Recent refactoring of image deployment (xenclient-oe/pull/1341)
introduced a work-around to handle staging for earlier releases.

Fix the work-around to properly detect the content of IMAGES_DIR.