### PR TITLE
Fix build error with large UID

### DIFF
--- a/Dockerfiles/generic-oe64
+++ b/Dockerfiles/generic-oe64
@@ -15,7 +15,7 @@ RUN apt-get update && \
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && \
         chmod a+x /usr/local/bin/repo
 
-RUN useradd -Ums /bin/bash -p build -u [UID] build && \
+RUN useradd -Ums /bin/bash -l -p build -u [UID] build && \
         usermod -aG sudo build
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen

--- a/Dockerfiles/openxt-buster-oe64
+++ b/Dockerfiles/openxt-buster-oe64
@@ -48,7 +48,7 @@ RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/
 # Symlink for troublesome packages
 RUN ln -s /lib64/ld-linux-x86-64.so.2 /lib/
 
-RUN useradd -Ums /bin/bash -p '""' -G sudo -u $UID $UNAME
+RUN useradd -Ums /bin/bash -l -p '""' -G sudo -u $UID $UNAME
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen

--- a/Dockerfiles/openxt-oe32
+++ b/Dockerfiles/openxt-oe32
@@ -42,7 +42,7 @@ RUN cd /tmp && \
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && \
         chmod a+x /usr/local/bin/repo
 
-RUN useradd -Ums /bin/bash -p $UNAME -u $UID $UNAME && \
+RUN useradd -Ums /bin/bash -l -p $UNAME -u $UID $UNAME && \
         usermod -aG sudo $UNAME
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \

--- a/Dockerfiles/openxt-oe64
+++ b/Dockerfiles/openxt-oe64
@@ -45,7 +45,7 @@ RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/
 # Symlink for troublesome packages
 RUN ln -s /lib64/ld-linux-x86-64.so.2 /lib/
 
-RUN useradd -Ums /bin/bash -p '""' -G sudo -u $UID $UNAME
+RUN useradd -Ums /bin/bash -l -p '""' -G sudo -u $UID $UNAME
 
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen


### PR DESCRIPTION
Docker has a known bug that causes a docker build to fail when a UID is large.
[docker build hangs/crashes when useradd with large UID #5419](https://github.com/moby/moby/issues/5419)

This PR works around this issue by opting to not add user to lastlog and faillog databases.