### PR TITLE
template: remove deprecated mirrors

### DIFF
--- a/templates/master/local.conf
+++ b/templates/master/local.conf
@@ -62,8 +62,6 @@ MIRRORS += " \
     http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
     git://anonscm.debian.org/collab-maint/ltrace.git    git://github.com/sparkleholic/ltrace.git \n \
     http://v3.sk/.*                                     https://openxt.ainfosec.com/mirror/ \n \
-    https://svwh.dl.sourceforge.net/project/linuxconsole/.*     https://openxt.ainfosec.com/mirror/ \n \
-    https://cgit.freedesktop.org/~airlied/vbetool/.*    https://openxt.ainfosec.com/mirror/ \n \
 "
 
 # TODO: This probably belongs to the xenclient-oe layer.


### PR DESCRIPTION
vbetool is not longer used (See https://github.com/OpenXT/xenclient-oe/pull/1357)
linuxconsole mirror seems to be stable.