### PR TITLE
config: add options for common debug switches

### DIFF
--- a/cmds/config
+++ b/cmds/config
@@ -36,6 +36,8 @@ config_generate_auto() {
     local branch="${1}"
     local forced="${2}"
     local rmwork="${3}"
+    local debug_tweaks="${4}"
+    local permissive="${5}"
     local auto_conf="${TOP}/${BUILD_DIR}/${CONF_DIR}/auto.conf"
 
     if [ -e "${auto_conf}" ] && \
@@ -73,6 +75,12 @@ EOF
 
     if [ "${rmwork}" = "true" ]; then
         echo "INHERIT += \"rm_work\"" >> ${auto_conf}
+    fi
+    if [ "${debug_tweaks}" = "true" ]; then
+        echo "EXTRA_IMAGE_FEATURES += \"debug-tweaks\"" >> ${auto_conf}
+    fi
+    if [ "${permissive}" = "true" ]; then
+        echo "DEFAULT_ENFORCING = \"permissive\"" >> ${auto_conf}
     fi
 }
 
@@ -137,6 +145,8 @@ Deployment command:
     -t: template name used for OE build config files temlate, default is the default
     -s: select an external sstate directory to use, default is per build_id sstate
     -b: branch to tag/use for the OpenXT repositories, default is build
+    -D: Enable debug tweaks by passing "debug-tweaks" to OE EXTRA_IMAGE_FEATURES.
+    -P: Switch SELinux to permissive by default in built images.
     --default: create the 'build' symlink to make this build directory the default one (see bordel -i).
     --force: overwrite any existing configuration if the build tree was already configured.
     --rmwork: inherit rm_work.bbclass, deleting temporary workspace.
@@ -155,8 +165,10 @@ config_main() {
     local forced="false"
     local rmwork="false"
     local repo_branch="true"
+    local debug_tweaks="false"
+    local permissive="false"
 
-    options=$(getopt -o t:s:b:h -l default,force,rmwork,no-repo-branch -- "$@")
+    options=$(getopt -o t:s:b:hDP -l default,force,rmwork,no-repo-branch -- "$@")
     if [ $? -ne 0 ]; then
         config_usage
         exit 1
@@ -180,6 +192,12 @@ config_main() {
         -h)
             config_usage
             exit 0
+            ;;
+        -D)
+            debug_tweaks="true"
+            ;;
+        -P)
+            permissive="true"
             ;;
         --default)
             default=true
@@ -221,7 +239,7 @@ config_main() {
             exit 1
         fi
     done
-    config_generate_auto "${branch}" "${forced}" "${rmwork}"
+    config_generate_auto "${branch}" "${forced}" "${rmwork}" "${debug_tweaks}" "${permissive}"
 
     if [ "${repo_branch}" = "true" ]; then
         pushd "${BASE_DIR}" >/dev/null

--- a/templates/master/local.conf
+++ b/templates/master/local.conf
@@ -99,9 +99,3 @@ XENCLIENT_RELEASE = "${OPENXT_RELEASE}"
 XENCLIENT_VERSION = "${OPENXT_VERSION}"
 include openxt-build-date.conf
 XENCLIENT_BUILD_DATE = "${OPENXT_BUILD_DATE}"
-
-# OpenXT: Set SELinux enforcing (Debug)
-DEFAULT_ENFORCING = "permissive"
-
-# OpenXT: Enable debugging tweaks.
-EXTRA_IMAGE_FEATURES += "debug-tweaks"

--- a/templates/pre-zeus/local.conf
+++ b/templates/pre-zeus/local.conf
@@ -91,9 +91,3 @@ XENCLIENT_RELEASE = "${OPENXT_RELEASE}"
 XENCLIENT_VERSION = "${OPENXT_VERSION}"
 include openxt-build-date.conf
 XENCLIENT_BUILD_DATE = "${OPENXT_BUILD_DATE}"
-
-# OpenXT: Set SELinux enforcing (Debug)
-DEFAULT_ENFORCING = "permissive"
-
-# OpenXT: Enable debugging tweaks.
-EXTRA_IMAGE_FEATURES += "debug-tweaks"

--- a/templates/stable-6/local.conf
+++ b/templates/stable-6/local.conf
@@ -118,8 +118,6 @@ XENCLIENT_VERSION = "${OPENXT_VERSION}"
 include openxt-build-date.conf
 XENCLIENT_BUILD_DATE = "${OPENXT_BUILD_DATE}"
 
-#EXTRA_IMAGE_FEATURES += "debug-tweaks"
-
 ### XXX: This should be set in distro.conf
 DISTRO_FEATURES_append += "selinux multiarch pam"
 

--- a/templates/stable-7/local.conf
+++ b/templates/stable-7/local.conf
@@ -119,8 +119,6 @@ XENCLIENT_VERSION = "${OPENXT_VERSION}"
 include openxt-build-date.conf
 XENCLIENT_BUILD_DATE = "${OPENXT_BUILD_DATE}"
 
-#EXTRA_IMAGE_FEATURES += "debug-tweaks"
-
 ### XXX: This should be set in distro.conf
 DISTRO_FEATURES_append += "selinux multiarch pam"
 

--- a/templates/stable-8/local.conf
+++ b/templates/stable-8/local.conf
@@ -95,9 +95,3 @@ XENCLIENT_RELEASE = "${OPENXT_RELEASE}"
 XENCLIENT_VERSION = "${OPENXT_VERSION}"
 include openxt-build-date.conf
 XENCLIENT_BUILD_DATE = "${OPENXT_BUILD_DATE}"
-
-# OpenXT: Set SELinux enforcing (Debug)
-DEFAULT_ENFORCING = "permissive"
-
-# OpenXT: Enable debugging tweaks.
-EXTRA_IMAGE_FEATURES += "debug-tweaks"

--- a/templates/stable-9/local.conf
+++ b/templates/stable-9/local.conf
@@ -95,12 +95,6 @@ XENCLIENT_VERSION = "${OPENXT_VERSION}"
 include openxt-build-date.conf
 XENCLIENT_BUILD_DATE = "${OPENXT_BUILD_DATE}"
 
-# OpenXT: Set SELinux enforcing (Debug)
-DEFAULT_ENFORCING = "permissive"
-
-# OpenXT: Enable debugging tweaks.
-EXTRA_IMAGE_FEATURES += "debug-tweaks"
-
 # rm_work had a bug until:
 #   0f537d985b rm_work: Handle race with -inital tasks
 # The fix depends on a change in bitbake, so don't use rm_work for recipes that


### PR DESCRIPTION
Add options for the config command to generate configuration with
debug-tweaks passed to OE images built and set SELinux to permissive by
default.

Amend the templates to reflect the new options.