### PR TITLE
docker: amend quoting issue

### DIFF
--- a/cmds/docker
+++ b/cmds/docker
@@ -60,7 +60,7 @@ docker_build() {
         -v "${HOME}/.gitconfig:/home/${user}/.gitconfig" \
         -v "${HOME}/.repoconfig:/home/${user}/.repoconfig" \
         -v "${HOME}/.repo_.gitconfig.json:/home/${user}/.repo_.gitconfig.json" \
-    	"${name}" "/home/${user}/openxt/openxt/bordel/bordel" "-i ${BUILD_ID}" "build"
+        "${name}" "/home/${user}/openxt/openxt/bordel/bordel" "-i" "${BUILD_ID}" "build"
 }
 
 docker_deploy() {


### PR DESCRIPTION
quoting `-i` and its argument together will result in a space being taken as part of BUILD_ID. In turn, this will fail to find the configuration when running "bordel -i id docker build".