### PR TITLE
bordel: let commands handle cwd

### DIFF
--- a/bordel
+++ b/bordel
@@ -98,14 +98,8 @@ if $(eval "${command}_need_conf") && ! $CONFIGURED; then
     exit 1
 fi
 
-if [ -d "${TOP}/${BUILD_DIR}" -a "${command}" != "config" ]; then
-	pushd "${TOP}/${BUILD_DIR}" >/dev/null
-fi
-
 call_cmd ${command} $@
 ret=$?
-
-popd > /dev/null 2>&1
 
 if [ $ret -ne 0 ]; then
     exit $ret

--- a/cmds/build
+++ b/cmds/build
@@ -22,6 +22,9 @@ build_main() {
 
     # Overwrite the build timestamp.
     echo "OPENXT_BUILD_DATE=\"$(date '+%T %D')\"" > ${CONF_DIR}/openxt-build-date.conf
+
+    pushd "${TOP}/${BUILD_DIR}" >/dev/null
+
     while read l ; do
         if [ -z "${l%%#*}" ]; then
             continue
@@ -40,4 +43,6 @@ build_main() {
         fi
 
     done < "${CONF_DIR}/build-manifest"
+
+    popd >/dev/null
 }

--- a/cmds/deploy
+++ b/cmds/deploy
@@ -185,6 +185,8 @@ deploy_main() {
     target="$1"
     shift 1
 
+    pushd "${TOP}/${BUILD_DIR}" >/dev/null
+
     case "${target}" in
         "iso-old") check_cmd_version "${target}"
                    deploy_iso_legacy $@ ;;
@@ -198,4 +200,6 @@ deploy_main() {
            deploy_usage 1
            ;;
     esac
+
+    popd >/dev/null
 }

--- a/cmds/stage
+++ b/cmds/stage
@@ -364,6 +364,9 @@ stage_need_conf() { return 0; }
 # Usage: stage <command>
 # Stage commands wrapper.
 stage_main() {
+
+    pushd "${TOP}/${BUILD_DIR}" >/dev/null
+
     for target in "$@"; do
         case "${target}" in
             "iso-old") check_cmd_version "${target}"
@@ -381,5 +384,7 @@ stage_main() {
                 ;;
         esac
     done
+
+    popd >/dev/null
 }
 


### PR DESCRIPTION
bordel used to call commands undex ${TOP}/${BUILD_DIR}, except when
running config or if the tree was not configured already.

Instead of handling this in the main dispatcher script, leave it up to each command to handle where its CWD is supposed to be:
- build, stage and deploy tend to run bitbake and use bitbake artefacts so run in ${TOP}/${BUILD_DIR}
- config, docker do not use bitbake directly and can configure ${BUILD_DIR} from ${TOP} (or elsewhere), most path behind absolute for these commands anyway.

https://github.com/apertussolutions/bordel/pull/39 options are easier to handle with this as otherwise the `realpath` on a relative path would be taken from `${TOP}/${BUILD_DIR}` (while `bordel` seems to be more commonly called from `${TOP}` and bitbake and related scripts are used from `${TOP}/${BUILD_DIR}`).