### PR TITLE
Convert from installer-part2-image to control.tar.bz2

### DIFF
--- a/cmds/stage
+++ b/cmds/stage
@@ -145,7 +145,12 @@ stage_repository() {
             *) img_format="file" ;;
         esac
 
-        local img_src_name="${img_src_label}-${machine}.${img_type}"
+        local img_src_name
+        case "${img_src_label}" in
+            control) img_src_name="${img_src_label}.${img_type}" ;;
+            *)       img_src_name="${img_src_label}-${machine}.${img_type}" ;;
+        esac
+
         local img_dst_name="${img_dst_label}.${img_type}"
 
         if [ "${img_id}" = "file" ]; then

--- a/templates/master/build-manifest
+++ b/templates/master/build-manifest
@@ -3,7 +3,6 @@
 #
 xenclient-initramfs-image MACHINE=xenclient-dom0
 xenclient-installer-image MACHINE=openxt-installer
-xenclient-installer-part2-image MACHINE=openxt-installer
 xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
 xenclient-dom0-image MACHINE=xenclient-dom0
 xenclient-uivm-image MACHINE=xenclient-uivm

--- a/templates/master/images-manifest
+++ b/templates/master/images-manifest
@@ -7,7 +7,7 @@
 # destination-label: Label used to name the image in the destination repository hierarchy (usually <image-id>-rootfs).
 # mount-point: Mount point of the image when deployed on a target.
 #
-openxt-installer control xenclient-installer-part2-image tar.bz2 control /
+openxt-installer control control tar.bz2 control /
 xenclient-dom0 dom0 xenclient-dom0-image ext3.gz dom0-rootfs /
 xenclient-uivm uivm xenclient-uivm-image ext3.vhd.gz uivm-rootfs /storage/uivm
 xenclient-ndvm ndvm xenclient-ndvm-image ext3.disk.vhd.gz ndvm-rootfs /storage/ndvm


### PR DESCRIPTION
xenclient-installer:do_deploy will now generate control.tar.bz2, so use
that generated file directly.  The xenclient-installer-part2-image no
longer needs to be created (and is in fact removed).

The file is now named control.tar.bz2, so it needs to be special cased
to avoid appending the machine name.

----
Thoughts on the code requiring the special case?

Poop, this probably breaks backwards compatibility.  Sigh.