### PR TITLE
templates: Remove dom0 initramfs from build-manifest

### DIFF
--- a/templates/master/build-manifest
+++ b/templates/master/build-manifest
@@ -1,7 +1,6 @@
 # Format:
 # <target-image-recipe> [ENV VARS]*
 #
-xenclient-initramfs-image MACHINE=xenclient-dom0
 xenclient-installer-image MACHINE=openxt-installer
 xenclient-installer-part2-image MACHINE=openxt-installer
 xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain


### PR DESCRIPTION
xenclient-oe commit c2dc8c01c0af "images: adapting dom0 image to use
vm-common class" made dom0-image depend on initramfs-image through the
class and INITRD_VM definition.  Therefore, a separate call to build the
initramfs is no longer needed.  Remove it.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>