### PR TITLE
build: Merge MACHINE definitions to cut down on builds

### DIFF
--- a/cmds/build
+++ b/cmds/build
@@ -16,6 +16,7 @@ build_need_conf() { return 0; }
 #   clean: Run "cleanall" on the image recipe before building it.
 build_main() {
     local mode=$1
+    local maybe_clean=""
 
     pushd "${TOP}/${BUILD_DIR}" >/dev/null
 
@@ -25,20 +26,30 @@ build_main() {
     # Overwrite the build timestamp.
     echo "OPENXT_BUILD_DATE=\"$(date '+%T %D')\"" > ${CONF_DIR}/openxt-build-date.conf
 
+    if [ "${mode}" = "clean" ]; then
+        # leading space to pretty print in error message below.
+        maybe_clean=" -c cleanall"
+    fi
+
+    if ! grep -q bitbake "${CONF_DIR}/build-manifest" ; then
+        cat >&2 << EOF
+build-manifest format change to require full bitbake commands
+e.g. MACHINE=xenclient-dom0 bitbake xenclient-dom0-image
+Either re-run \`bordel config\` or manually update ${CONF_DIR}/build-manifest
+with something like \`sed 's/\([^ ]*\) \(.*\)/\2 bitbake \1/'\` to build.
+EOF
+        return 1
+    fi
+
     while read l ; do
         if [ -z "${l%%#*}" ]; then
             continue
         fi
 
-        local entry=(${l})
-        local image="${entry[0]}"
-        local env="${entry[@]:1}"
-
-        if [ "${mode}" = "clean" ]; then
-            eval ${env} bitbake -c cleanall "${image}"
-        fi
-        if ! eval ${env} bitbake "${image}" ; then
-            echo "${env} bitbake \"${image}\" failed." >&2
+        # No quotes so this expands out the line and runs it as a command
+        #  e.g. MACHINE=xenclient-dom0 bitbake xenclient-dom0-image
+        if ! env $l $maybe_clean ; then
+            echo "build-manifest command \"$l$maybe_clean\" failed." >&2
             return 1
         fi
 

--- a/templates/master/build-manifest
+++ b/templates/master/build-manifest
@@ -1,10 +1,10 @@
 # Format:
-# <target-image-recipe> [ENV VARS]*
+# [ENV VARS]* bitake <target-image-recipe>*
 #
-xenclient-installer-image MACHINE=openxt-installer
-xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
-xenclient-dom0-image MACHINE=xenclient-dom0
-xenclient-uivm-image MACHINE=xenclient-uivm
-xenclient-ndvm-image MACHINE=xenclient-ndvm
-xenclient-syncvm-image MACHINE=xenclient-syncvm
-package-index MACHINE=xenclient-dom0
+MACHINE=openxt-installer bitbake xenclient-installer-image
+MACHINE=xenclient-stubdomain bitbake xenclient-stubdomain-initramfs-image
+MACHINE=xenclient-dom0 bitbake xenclient-dom0-image
+MACHINE=xenclient-uivm bitbake xenclient-uivm-image
+MACHINE=xenclient-ndvm bitbake xenclient-ndvm-image
+MACHINE=xenclient-syncvm bitbake xenclient-syncvm-image
+MACHINE=xenclient-dom0 bitbake package-index

--- a/templates/pre-zeus/build-manifest
+++ b/templates/pre-zeus/build-manifest
@@ -1,11 +1,11 @@
 # Format:
-# <target-image-recipe> [ENV VARS]*
+# [ENV VARS]* bitake <target-image-recipe>*
 #
-xenclient-initramfs-image MACHINE=xenclient-dom0
-xenclient-installer-image MACHINE=openxt-installer
-xenclient-installer-part2-image MACHINE=openxt-installer
-xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
-xenclient-dom0-image MACHINE=xenclient-dom0
-xenclient-uivm-image MACHINE=xenclient-uivm
-xenclient-ndvm-image MACHINE=xenclient-ndvm
-xenclient-syncvm-image MACHINE=xenclient-syncvm
+MACHINE=xenclient-dom0 bitbake xenclient-initramfs-image
+MACHINE=openxt-installer bitbake xenclient-installer-image
+MACHINE=openxt-installer bitbake xenclient-installer-part2-image
+MACHINE=xenclient-stubdomain bitbake xenclient-stubdomain-initramfs-image
+MACHINE=xenclient-dom0 bitbake xenclient-dom0-image
+MACHINE=xenclient-uivm bitbake xenclient-uivm-image
+MACHINE=xenclient-ndvm bitbake xenclient-ndvm-image
+MACHINE=xenclient-syncvm bitbake xenclient-syncvm-image

--- a/templates/stable-6/build-manifest
+++ b/templates/stable-6/build-manifest
@@ -1,11 +1,11 @@
 # Format:
-# <target-image-recipe> [ENV VARS]*
+# [ENV VARS]* bitake <target-image-recipe>*
 #
-xenclient-dom0:xenclient-initramfs-image
-xenclient-dom0:xenclient-installer-image
-xenclient-dom0:xenclient-installer-part2-image
-xenclient-stubdomain:xenclient-stubdomain-initramfs-image
-xenclient-dom0:xenclient-dom0-image
-xenclient-uivm:xenclient-uivm-image
-xenclient-ndvm:xenclient-ndvm-image
-xenclient-syncvm:xenclient-syncvm-image
+MACHINE=xenclient-dom0 bitbake xenclient-initramfs-image
+MACHINE=xenclient-dom0 bitbake xenclient-installer-image
+MACHINE=xenclient-dom0 bitbake xenclient-installer-part2-image
+MACHINE=xenclient-stubdomain bitbake xenclient-stubdomain-initramfs-image
+MACHINE=xenclient-dom0 bitbake xenclient-dom0-image
+MACHINE=xenclient-uivm bitbake xenclient-uivm-image
+MACHINE=xenclient-ndvm bitbake xenclient-ndvm-image
+MACHINE=xenclient-syncvm bitbake xenclient-syncvm-image

--- a/templates/stable-7/build-manifest
+++ b/templates/stable-7/build-manifest
@@ -1,11 +1,11 @@
 # Format:
-# <target-image-recipe> [ENV VARS]*
+# [ENV VARS]* bitake <target-image-recipe>*
 #
-xenclient-initramfs-image MACHINE=xenclient-dom0
-xenclient-installer-image MACHINE=xenclient-dom0
-xenclient-installer-part2-image MACHINE=xenclient-dom0
-xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
-xenclient-dom0-image MACHINE=xenclient-dom0
-xenclient-uivm-image MACHINE=xenclient-uivm
-xenclient-ndvm-image MACHINE=xenclient-ndvm
-xenclient-syncvm-image MACHINE=xenclient-syncvm
+MACHINE=xenclient-dom0 bitbake xenclient-initramfs-image
+MACHINE=xenclient-dom0 bitbake xenclient-installer-image
+MACHINE=xenclient-dom0 bitbake xenclient-installer-part2-image
+MACHINE=xenclient-stubdomain bitbake xenclient-stubdomain-initramfs-image
+MACHINE=xenclient-dom0 bitbake xenclient-dom0-image
+MACHINE=xenclient-uivm bitbake xenclient-uivm-image
+MACHINE=xenclient-ndvm bitbake xenclient-ndvm-image
+MACHINE=xenclient-syncvm bitbake xenclient-syncvm-image

--- a/templates/stable-8/build-manifest
+++ b/templates/stable-8/build-manifest
@@ -1,12 +1,12 @@
 # Format:
-# <target-image-recipe> [ENV VARS]*
+# [ENV VARS]* bitake <target-image-recipe>*
 #
-xenclient-initramfs-image MACHINE=xenclient-dom0
-xenclient-installer-image MACHINE=openxt-installer
-xenclient-installer-part2-image MACHINE=openxt-installer
-xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
-xenclient-dom0-image MACHINE=xenclient-dom0
-xenclient-uivm-image MACHINE=xenclient-uivm
-xenclient-ndvm-image MACHINE=xenclient-ndvm
-xenclient-syncvm-image MACHINE=xenclient-syncvm
-package-index MACHINE=xenclient-dom0
+MACHINE=xenclient-dom0 bitbake xenclient-initramfs-image
+MACHINE=openxt-installer bitbake xenclient-installer-image
+MACHINE=openxt-installer bitbake xenclient-installer-part2-image
+MACHINE=xenclient-stubdomain bitbake xenclient-stubdomain-initramfs-image
+MACHINE=xenclient-dom0 bitbake xenclient-dom0-image
+MACHINE=xenclient-uivm bitbake xenclient-uivm-image
+MACHINE=xenclient-ndvm bitbake xenclient-ndvm-image
+MACHINE=xenclient-syncvm bitbake xenclient-syncvm-image
+MACHINE=xenclient-dom0 bitbake package-index

--- a/templates/stable-9/build-manifest
+++ b/templates/stable-9/build-manifest
@@ -1,13 +1,13 @@
 # Format:
-# <target-image-recipe> [ENV VARS]*
+# [ENV VARS]* bitake <target-image-recipe>*
 #
-xenclient-initramfs-image MACHINE=xenclient-dom0
-xenclient-installer-image MACHINE=openxt-installer
-xenclient-installer-part2-image MACHINE=openxt-installer
-xenclient-upgrade-compat-image MACHINE=upgrade-compat
-xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
-xenclient-dom0-image MACHINE=xenclient-dom0
-xenclient-uivm-image MACHINE=xenclient-uivm
-xenclient-ndvm-image MACHINE=xenclient-ndvm
-xenclient-syncvm-image MACHINE=xenclient-syncvm
-package-index MACHINE=xenclient-dom0
+MACHINE=xenclient-dom0 bitbake xenclient-initramfs-image
+MACHINE=openxt-installer bitbake xenclient-installer-image
+MACHINE=openxt-installer bitbake xenclient-installer-part2-image
+MACHINE=upgrade-compat bitbake xenclient-upgrade-compat-image
+MACHINE=xenclient-stubdomain bitbake xenclient-stubdomain-initramfs-image
+MACHINE=xenclient-dom0 bitbake xenclient-dom0-image
+MACHINE=xenclient-uivm bitbake xenclient-uivm-image
+MACHINE=xenclient-ndvm bitbake xenclient-ndvm-image
+MACHINE=xenclient-syncvm bitbake xenclient-syncvm-image
+MACHINE=xenclient-dom0 bitbake package-index

--- a/templates/zeus/build-manifest
+++ b/templates/zeus/build-manifest
@@ -1,12 +1,12 @@
 # Format:
-# <target-image-recipe> [ENV VARS]*
+# [ENV VARS]* bitake <target-image-recipe>*
 #
-xenclient-initramfs-image MACHINE=xenclient-dom0
-xenclient-installer-image MACHINE=openxt-installer
-xenclient-installer-part2-image MACHINE=openxt-installer
-xenclient-stubdomain-initramfs-image MACHINE=xenclient-stubdomain
-xenclient-dom0-image MACHINE=xenclient-dom0
-xenclient-uivm-image MACHINE=xenclient-uivm
-xenclient-ndvm-image MACHINE=xenclient-ndvm
-xenclient-syncvm-image MACHINE=xenclient-syncvm
-package-index MACHINE=xenclient-dom0
+MACHINE=xenclient-dom0 bitbake xenclient-initramfs-image
+MACHINE=openxt-installer bitbake xenclient-installer-image
+MACHINE=openxt-installer bitbake xenclient-installer-part2-image
+MACHINE=xenclient-stubdomain bitbake xenclient-stubdomain-initramfs-image
+MACHINE=xenclient-dom0 bitbake xenclient-dom0-image
+MACHINE=xenclient-uivm bitbake xenclient-uivm-image
+MACHINE=xenclient-ndvm bitbake xenclient-ndvm-image
+MACHINE=xenclient-syncvm bitbake xenclient-syncvm-image
+MACHINE=xenclient-dom0 bitbake package-index


### PR DESCRIPTION
We can speed up builds be running identical MACHINE & other environment
variable builds in parallel.  The env vars will need sorted and the
associated images tracked.

One tricky thing is the implicit dependency of stubdomain-image being
built before dom0-image.  Take care to order building stubdomain-image
first.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

-----
This isn't really helpful for a plain build with the removal of installer-part2-image and initramfs-image.  I guess it would help with package index.  Adds some complexity.