### PR TITLE
Dockerfiles: Install symlinks for openxt versions

### DIFF
--- a/Dockerfiles/openxt-dunfell
+++ b/Dockerfiles/openxt-dunfell
@@ -1,0 +1,1 @@
+openxt-buster-oe64

--- a/Dockerfiles/openxt-master
+++ b/Dockerfiles/openxt-master
@@ -1,0 +1,1 @@
+openxt-buster-oe64

--- a/Dockerfiles/openxt-stable-9
+++ b/Dockerfiles/openxt-stable-9
@@ -1,0 +1,1 @@
+openxt-oe64

--- a/Dockerfiles/openxt-zeus
+++ b/Dockerfiles/openxt-zeus
@@ -1,0 +1,1 @@
+openxt-buster-oe64


### PR DESCRIPTION
Provide symlinks from the openxt version name to the compatible
container image.  This clears up which container image is needed to
build a particular openxt version.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

-----
We discussed doing this at some point.  I think the symlinks are correct.  Do we care about older versions?