### PR TITLE
cert: change default md to sha384

### DIFF
--- a/cmds/certs
+++ b/cmds/certs
@@ -36,7 +36,7 @@ certs_create_selfsigned() {
         cat - > "${x509_conf}" <<EOF
 [ req ]
 default_bits = 4096
-default_md = sha256
+default_md = sha384
 prompt = no
 distinguished_name = req_distinguished_name
 string_mask = utf8only


### PR DESCRIPTION
OpenXT's dom0 kernel defconfig currently has:
- CONFIG_CRYPTO_SHA256=m
- CONFIG_CRYPTO_SHA512=y
- CONFIG_MODULE_SIG_SHA384=y
- CONFIG_MODULE_SIG_HASH="sha384"

Switch the default certificate to avoid dependency loop when verifying signatures.