### PR TITLE
master: amend template for vGlass/module signing

### DIFF
--- a/templates/master/bblayers.conf
+++ b/templates/master/bblayers.conf
@@ -21,4 +21,6 @@ BBLAYERS ?= " \
   ${LAYERS_DIR}/meta-openxt-ocaml-platform \
   ${LAYERS_DIR}/meta-openxt-haskell-platform \
   ${LAYERS_DIR}/meta-virtualization \
+  ${LAYERS_DIR}/meta-qt5 \
+  ${LAYERS_DIR}/meta-vglass \
   "

--- a/templates/master/local.conf
+++ b/templates/master/local.conf
@@ -69,6 +69,8 @@ REPO_PROD_CACERT="${OPENXT_CERTS_DIR}/prod-cacert.pem"
 REPO_DEV_CACERT="${OPENXT_CERTS_DIR}/dev-cacert.pem"
 REPO_DEV_SIGNING_CERT="${OPENXT_CERTS_DIR}/dev-cacert.pem"
 REPO_DEV_SIGNING_DEV="${OPENXT_CERTS_DIR}/dev-cakey.pem"
+KERNEL_MODULE_SIG_CERT="${OPENXT_CERTS_DIR}/kernel_cert.pem"
+KERNEL_MODULE_SIG_KEY="${OPENXT_CERTS_DIR}/kernel_key.pem"
 
 # If ENABLE_BINARY_LOCALE_GENERATION is set to "1", you can limit locales
 # generated to the list provided by GLIBC_GENERATE_LOCALES. This is huge


### PR DESCRIPTION
Add meta-qt5 and meta-vglass to `bblayers.conf` as required to build vglass.

Since https://github.com/OpenXT/xenclient-oe/pull/1401 and associated PRs, `KERNEL_MODULE_SIG_{KEY,CERT}` have to be set in the configuration in order to correctly sign the modules and still be able to use mirrored shared-state resources. Add default values.
Test signing certificates can be generated using https://github.com/apertussolutions/bordel/pull/51.
OpenXT's kernel configuration require signing at the moment, and changing the kernel configurations is required to build without this.