### PR TITLE
stage: replace old/legacy and workout image names

### DIFF
--- a/cmds/deploy
+++ b/cmds/deploy
@@ -12,7 +12,7 @@ deploy_iso_legacy() {
     call_cmd "stage" "repository" || return $?
     # Prepare ISO image layout.
     # TODO: Amend syslinux files to reflect versions & such
-    call_cmd "stage" "iso-old" || return $?
+    call_cmd "stage" "iso" || return $?
 
     genisoimage -o "${iso_path}" \
         -b "isolinux/isolinux.bin" -c "isolinux/boot.cat" \
@@ -133,12 +133,6 @@ __deploy_pxe() {
         rsync -avzr "${STAGING_DIR}/repository/" ${answer_files[@]} "${repo_dst}"
     fi
 }
-deploy_pxe_legacy() {
-    # Prepare PXE staging.
-    call_cmd "stage" "pxe-old" || return $?
-
-    __deploy_pxe $@
-}
 deploy_pxe() {
     # Prepare PXE staging.
     call_cmd "stage" "pxe" || return $?
@@ -192,8 +186,7 @@ deploy_main() {
                    deploy_iso_legacy $@ ;;
         "iso") check_cmd_version "${target}"
                deploy_iso $@ ;;
-        "pxe-old") deploy_pxe_legacy $@ ;;
-        "pxe") deploy_pxe $@ ;;
+        "pxe"*) deploy_pxe $@ ;;
         "help") deploy_usage 0 ;;
         "update") deploy_update ;;
         *) echo "Unknown staging command \`${target}'." >&2

--- a/cmds/deploy
+++ b/cmds/deploy
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 # Usage: deploy_iso_legacy
 # Run the required staging steps and generate the ISO image.
 deploy_iso_legacy() {
@@ -9,10 +11,10 @@ deploy_iso_legacy() {
 
     # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
     # meta files.
-    call_cmd "stage" "repository" || return $?
+    call_cmd "stage" "repository"
     # Prepare ISO image layout.
     # TODO: Amend syslinux files to reflect versions & such
-    call_cmd "stage" "iso" || return $?
+    call_cmd "stage" "iso"
 
     genisoimage -o "${iso_path}" \
         -b "isolinux/isolinux.bin" -c "isolinux/boot.cat" \
@@ -48,10 +50,10 @@ deploy_iso() {
 
     # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
     # meta files.
-    call_cmd "stage" "repository" || return $?
+    call_cmd "stage" "repository"
     # Prepare ISO image layout.
     # TODO: Amend syslinux files to reflect versions & such
-    call_cmd "stage" "iso" || return $?
+    call_cmd "stage" "iso"
 
     xorriso -as mkisofs \
         -o "${iso_path}" \
@@ -80,7 +82,7 @@ deploy_iso() {
 deploy_update() {
     # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
     # meta files.
-    call_cmd "stage" "repository" || return $?
+    call_cmd "stage" "repository"
 
     tar -C "${STAGING_DIR}/repository" \
         -cf "${DEPLOY_DIR}/update.tar" packages.main
@@ -99,7 +101,7 @@ __deploy_pxe() {
 
     # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
     # meta files.
-    call_cmd "stage" "repository" || return $?
+    call_cmd "stage" "repository"
 
     while getopts "hr:" opt; do
         case "${opt}" in
@@ -135,7 +137,7 @@ __deploy_pxe() {
 }
 deploy_pxe() {
     # Prepare PXE staging.
-    call_cmd "stage" "pxe" || return $?
+    call_cmd "stage" "pxe"
 
     __deploy_pxe $@
 }

--- a/cmds/stage
+++ b/cmds/stage
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 stage_sign_repository() {
     if [ ! -f "${REPOSITORY_DIR}/XC-PACKAGES" ]; then
         echo "Repository in \`${REPOSITORY_DIR}' is not ready yet, XC-PACKAGES is missing." >&2
@@ -74,7 +76,7 @@ stage_build_output_by_suffix() {
     for f in "${IMAGES_DIR}/${1}"*"${2}"; do
         if [ ! -e "${f}" ]; then
             echo "${f} is not ready yet." >&2
-            break
+            return 1
         fi
         cp -rv -L "${f}" "${dst}/$(basename "${f}")"
     done

--- a/cmds/stage
+++ b/cmds/stage
@@ -172,14 +172,14 @@ stage_repository() {
     stage_sign_repository
 }
 
-# Usage: stage_iso <machine>
+# Usage: stage_iso
 # Copy images from the deployment directory (DEPLOY_DIR) of the installer
 # machine to the iso staging area (STAGING_DIR) that are specific to ISO image
 # generation.
 stage_iso() {
-    local machine="$1"
+    local machine="$( awk '$2 == "control" { print $1 }' "${CONF_DIR}/images-manifest")"
     local isolinux_subdir="iso/isolinux"
-    local image_name="xenclient-installer-image-${machine}"
+    local image_name="$(basename "$(echo "${DEPLOY_DIR}/images/${machine}/"*installer-image*.rootfs.cpio.gz)")"
     # Post do_deploy refactoring path (see IMAGE_LINK in xenclient-oe).
     local iso_src_path="${machine}/${image_name}/iso"
     if [ ! -d "${IMAGES_DIR}/${iso_src_path}" ]; then
@@ -202,8 +202,7 @@ stage_iso() {
     sed -i -e "s#[$]OPENXT_BUILD_ID#${OPENXT_BUILD_ID}#g" "${STAGING_DIR}/${isolinux_subdir}/bootmsg.txt"
 
     # --- Stage installer initrd.
-    local initrd_type="cpio.gz"
-    local initrd_src_path="${machine}/${image_name}.${initrd_type}"
+    local initrd_src_path="${machine}/${image_name}"
     local initrd_dst_name="rootfs.gz"
     local initrd_dst_path="${isolinux_subdir}/${initrd_dst_name}"
 
@@ -278,14 +277,14 @@ stage_iso() {
     fi
 }
 
-# Usage: stage_pxe <machine>
+# Usage: stage_pxe
 # Copy images from the deployment directory (DEPLOY_DIR) of the installer
 # machine to the pxe staging area (STAGING_DIR).
 stage_pxe() {
-    local machine="$1"
+    local machine="$( awk '$2 == "control" { print $1 }' "${CONF_DIR}/images-manifest")"
     local pxe_subdir="pxe"
     # TODO: Well this is ugly.
-    local image_name="xenclient-installer-image-${machine}"
+    local image_name=$(basename $(echo "${DEPLOY_DIR}/images/${machine}/"*installer-image*.rootfs.cpio.gz))
 
     # --- Stage installer bulk files.
     local pxe_src_path="${machine}/${image_name}/netboot/"
@@ -297,8 +296,7 @@ stage_pxe() {
     stage_build_output_by_suffix "${pxe_src_path}" "${pxe_src_suffix}" "${pxe_subdir}"
 
     # --- Stage installer initrd.
-    local initrd_type="cpio.gz"
-    local initrd_src_path="${machine}/${image_name}.${initrd_type}"
+    local initrd_src_path="${machine}/${image_name}"
     local initrd_dst_name="rootfs.gz"
     local initrd_dst_path="${pxe_subdir}/${initrd_dst_name}"
 
@@ -355,9 +353,7 @@ stage_usage() {
 Usage: stage <command> ...
     Run a stage command to populate STAGING_DIR with the build outputs.
 Stage Commands:
-    iso-old: Copy BIOS/ISO installer related build results, from Bitbake deployment directory to the staging area.
     iso: Copy EFI/ISO installer related build results, from Bitbake deployment directory to the staging area.
-    pxe-old: Copy PXE files for the installer from Bitbake deployment directory to the staging area.
     pxe: Copy PXE files for the installer from Bitbake deployment directory to the staging area.
     repository: Copy build results from Bitbake deployment directory to the staging area and update the relevant meta-data.
 EOF
@@ -374,14 +370,8 @@ stage_main() {
 
     for target in "$@"; do
         case "${target}" in
-            "iso-old") check_cmd_version "${target}"
-                       stage_iso xenclient-dom0 ;;
-            "iso") check_cmd_version "${target}"
-                   stage_iso openxt-installer ;;
-            "pxe-old") check_cmd_version "${target}"
-                       stage_pxe xenclient-dom0 ;;
-            "pxe") check_cmd_version "${target}"
-                   stage_pxe openxt-installer ;;
+            "iso"*) stage_iso ;;
+            "pxe"*) stage_pxe ;;
             "repository") stage_repository ;;
             "help") stage_usage 0 ;;
             *)  echo "Unknown staging command \`${target}'." >&2


### PR DESCRIPTION
stage depend on a couple of hardcoded names that make the manifests unconfigurable. These names are fairly standard, although they changed in time since earlier versions. The installer image name can be deduced from the MACHINE.

Add the work-around to get the image name from the MACHINE selected in the IMAGE_MANIFEST.

This should justify a change in the manifests format to avoid relying on naming for the installer image. Keep the current format for now.