### PR TITLE
confi: regression with set -e

### DIFF
--- a/bordel
+++ b/bordel
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Usage: usage <exit-code>
 # Display the usage of this script.
 usage() {

--- a/cmds/config
+++ b/cmds/config
@@ -235,7 +235,10 @@ config_main() {
     fi
 
     pushd "${BASE_DIR}" > /dev/null
-    ln -sf .repo/projects/openxt mirror
+    # starting with zeus branch, this is no longer required.
+    if [ -e .repo/projects/openxt ]; then
+        ln -sf .repo/projects/openxt mirror
+    fi
     popd > /dev/null 2>&1
 
     config_generate_dir "${sstate_dir}"

--- a/cmds/deploy
+++ b/cmds/deploy
@@ -1,7 +1,5 @@
 #! /bin/bash
 
-set -e
-
 # Usage: deploy_iso_legacy
 # Run the required staging steps and generate the ISO image.
 deploy_iso_legacy() {

--- a/cmds/stage
+++ b/cmds/stage
@@ -1,7 +1,5 @@
 #! /bin/bash
 
-set -e
-
 stage_sign_repository() {
     if [ ! -f "${REPOSITORY_DIR}/XC-PACKAGES" ]; then
         echo "Repository in \`${REPOSITORY_DIR}' is not ready yet, XC-PACKAGES is missing." >&2


### PR DESCRIPTION
Introduced by both/either:
6d94e64 deploy: exit on failure
cc7dafe stage: exit on failure

set -e was introduced to fail as soon as possible, but these commands are registered after sourcing each sub-script (named after the command) via the function register_command. The side effect: set -e is enabled for anything using bordel. This is a bit  neaky, it should be done in bordel directly.


The legacy mirror directory used to be linked for up to stable-9 versions. If the target of the symlink does not exist, test -e will fail, but the symlink itself exists, hence mkdir will fail.

To support the old manifests/layers, the link should be kept. This can be done by looking for the git mirrors created by repo. Zeus and later branches will not setup local mirrors.

Repro: https://openxt.ainfosec.com/buildbot/#/builders/20/builds/41