### PR TITLE
docker: display help if no command is passed

### DIFF
--- a/cmds/docker
+++ b/cmds/docker
@@ -172,8 +172,8 @@ docker_main() {
         shift
     done
 
-    cmd="$1"
-    shift 1
+    cmd="${1:-help}"
+    [ -n "$1" ] && shift
 
     case "${cmd}" in
         "list") docker_list "${dockerfiles}" ;;


### PR DESCRIPTION
With `set -e`, `shift` fails and exit the script if there is no argument left.