### PR TITLE
Add make command

### DIFF
--- a/cmds/build
+++ b/cmds/build
@@ -20,6 +20,7 @@ build_main() {
     pushd "${TOP}/${BUILD_DIR}" >/dev/null
 
     # Source build_env to get access to necessary OE variables.
+    # cd-s into BUILD_DIR.. after it redefined it.
     # shellcheck disable=SC1090
     . "${TOP}/${BUILD_DIR}/build_env"
 

--- a/cmds/config
+++ b/cmds/config
@@ -122,13 +122,13 @@ if [ "\$_" == "\$0" ]; then
     return 1
 fi
 
-BUILD_DIR="\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ABS_BUILD_DIR="\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-BBPATH="\${BUILD_DIR}/layers/bitbake/bin:\${BUILD_DIR}/layers/openembedded-core/scripts:"
+BBPATH="\${ABS_BUILD_DIR}/layers/bitbake/bin:\${ABS_BUILD_DIR}/layers/openembedded-core/scripts:"
 
 BB_ENV_EXTRAWHITE="MACHINE DISTRO BUILD_UID LAYERS_DIR"
-LAYERS_DIR="\${BUILD_DIR}/layers"
-BUILDDIR="\${BUILD_DIR}"
+LAYERS_DIR="\${ABS_BUILD_DIR}/layers"
+BUILDDIR="\${ABS_BUILD_DIR}"
 PATH=\$BBPATH\$(echo "\$PATH" | sed -e "s|:\$BBPATH|:|g" -e "s|^\$BBPATH||")
 
 unset BBPATH

--- a/cmds/deploy
+++ b/cmds/deploy
@@ -7,13 +7,6 @@ deploy_iso_legacy() {
     local iso_name="openxt-installer.iso"
     local iso_path="${DEPLOY_DIR}/${iso_name}"
 
-    # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
-    # meta files.
-    call_cmd "stage" "repository"
-    # Prepare ISO image layout.
-    # TODO: Amend syslinux files to reflect versions & such
-    call_cmd "stage" "iso"
-
     if ! genisoimage -o "${iso_path}" \
         -b "isolinux/isolinux.bin" -c "isolinux/boot.cat" \
         -no-emul-boot \
@@ -44,13 +37,6 @@ deploy_iso() {
         return 1
     fi
 
-    # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
-    # meta files.
-    call_cmd "stage" "repository"
-    # Prepare ISO image layout.
-    # TODO: Amend syslinux files to reflect versions & such
-    call_cmd "stage" "iso"
-
     xorriso -as mkisofs \
         -o "${iso_path}" \
         -isohybrid-mbr "${STAGING_DIR}/iso/isolinux/isohdpfx.bin" \
@@ -76,10 +62,6 @@ deploy_iso() {
 # Usage: deploy_update
 # Run the required staging steps and generate the update tarball
 deploy_update() {
-    # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
-    # meta files.
-    call_cmd "stage" "repository"
-
     tar -C "${STAGING_DIR}/repository" \
         -cf "${DEPLOY_DIR}/update.tar" packages.main
 }
@@ -94,10 +76,6 @@ deploy_pxe_usage() {
 __deploy_pxe() {
     local pxe_staging="${STAGING_DIR}/pxe"
     local repo_dst=""
-
-    # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
-    # meta files.
-    call_cmd "stage" "repository"
 
     while getopts "hr:" opt; do
         case "${opt}" in
@@ -131,9 +109,6 @@ __deploy_pxe() {
     fi
 }
 deploy_pxe() {
-    # Prepare PXE staging.
-    call_cmd "stage" "pxe"
-
     __deploy_pxe "$@"
 }
 
@@ -174,7 +149,45 @@ deploy_need_conf() { return 0; }
 # Deploy OpenXT on the selected installation media.
 deploy_main() {
     target="$1"
-    shift 1
+    shift
+    local stage_repo=0
+    local stage_iso=0
+    local stage_pxe=0
+
+    case "${target}" in
+        "iso*")
+            check_cmd_version "${target}"
+            stage_repo=1
+            stage_iso=1
+            ;;
+        "pxe"*)
+            stage_repo=1
+            stage_pxe=1
+            ;;
+        "update")
+            stage_repo=1
+            ;;
+        "help") deploy_usage 0
+            return
+            ;;
+    esac
+
+    if [ "$stage_repo" -eq 1 ] ; then
+        # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
+        # meta files.
+        call_cmd "stage" "repository"
+    fi
+
+    if [ "$stage_iso" -eq 1 ] ; then
+        # Prepare ISO image layout.
+        # TODO: Amend syslinux files to reflect versions & such
+        call_cmd "stage" "iso"
+    fi
+
+    if [ "$stage_pxe" -eq 1 ] ; then
+        # Prepare PXE staging.
+        call_cmd "stage" "pxe"
+    fi
 
     pushd "${TOP}/${BUILD_DIR}" >/dev/null
 
@@ -186,9 +199,6 @@ deploy_main() {
         "pxe"*) deploy_pxe "$@" ;;
         "help") deploy_usage 0 ;;
         "update") deploy_update ;;
-        *) echo "Unknown staging command \`${target}'." >&2
-           deploy_usage 1
-           ;;
     esac
 
     popd >/dev/null

--- a/cmds/deploy
+++ b/cmds/deploy
@@ -57,6 +57,8 @@ deploy_iso() {
         -quiet \
         "${STAGING_DIR}/iso" \
         "${STAGING_DIR}/repository"
+
+    echo "ISO created: $iso_path"
 }
 
 # Usage: deploy_update
@@ -64,6 +66,8 @@ deploy_iso() {
 deploy_update() {
     tar -C "${STAGING_DIR}/repository" \
         -cf "${DEPLOY_DIR}/update.tar" packages.main
+
+    echo "OTA update tarball created: ${DEPLOY_DIR}/update.tar"
 }
 
 deploy_pxe_usage() {
@@ -139,6 +143,7 @@ Deployment command list:
         pxe: Copy a PXE compatible OpenXT installer to the given
              [<tftp-user>@]<tftp-server>:<tftp-path> tftp server, and
              setup the installer to fetch repository from <repo-uri>
+     update: Create the update.tar OTA package.
 End-of-usage
     exit "${1:-0}"
 }

--- a/cmds/deploy
+++ b/cmds/deploy
@@ -144,6 +144,9 @@ Deployment command list:
              [<tftp-user>@]<tftp-server>:<tftp-path> tftp server, and
              setup the installer to fetch repository from <repo-uri>
      update: Create the update.tar OTA package.
+
+Multiple commands can be specified together.  e.g. deploy update iso.
+If pxe is used, it must be last.
 End-of-usage
     exit "${1:-0}"
 }
@@ -153,29 +156,35 @@ deploy_need_conf() { return 0; }
 # Usage: deploy <command>
 # Deploy OpenXT on the selected installation media.
 deploy_main() {
-    target="$1"
-    shift
     local stage_repo=0
     local stage_iso=0
     local stage_pxe=0
 
-    case "${target}" in
-        "iso*")
-            check_cmd_version "${target}"
-            stage_repo=1
-            stage_iso=1
-            ;;
-        "pxe"*)
-            stage_repo=1
-            stage_pxe=1
-            ;;
-        "update")
-            stage_repo=1
-            ;;
-        "help") deploy_usage 0
-            return
-            ;;
-    esac
+    targets=()
+    for target in "$@" ; do
+        targets+=("$target")
+        shift
+
+        case "${target}" in
+            iso*)
+                check_cmd_version "${target}"
+                stage_repo=1
+                stage_iso=1
+                ;;
+            pxe*)
+                stage_repo=1
+                stage_pxe=1
+                # break to maintain "$@" for deploy_pxe
+                break
+                ;;
+            update)
+                stage_repo=1
+                ;;
+            help) deploy_usage 0
+                return
+                ;;
+        esac
+    done
 
     if [ "$stage_repo" -eq 1 ] ; then
         # Prepare repository layout and write XC-{PACKAGE,REPOSITORY,SIGNATURE}
@@ -196,15 +205,17 @@ deploy_main() {
 
     pushd "${TOP}/${BUILD_DIR}" >/dev/null
 
-    case "${target}" in
-        "iso-old") check_cmd_version "${target}"
-                   deploy_iso_legacy "$@" ;;
-        "iso") check_cmd_version "${target}"
-               deploy_iso "$@" ;;
-        "pxe"*) deploy_pxe "$@" ;;
-        "help") deploy_usage 0 ;;
-        "update") deploy_update ;;
-    esac
+    for target in "${targets[@]}"; do
+        case "${target}" in
+            "iso-old") check_cmd_version "${target}"
+                       deploy_iso_legacy ;;
+            "iso") check_cmd_version "${target}"
+                   deploy_iso ;;
+            "pxe"*) deploy_pxe "$@" ;;
+            "help") deploy_usage 0 ;;
+            "update") deploy_update ;;
+        esac
+    done
 
     popd >/dev/null
 }

--- a/cmds/make
+++ b/cmds/make
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+make_describe() {
+    echo "Build all the images and then deploy the iso and update."
+}
+
+make_need_conf() { return 0; }
+
+make_main() {
+    call_cmd "build"
+    call_cmd "deploy" "iso" "update"
+}


### PR DESCRIPTION
Re-jig the code so you can call `bordel make` which builds the VMs and then deploys an iso and update tarball.

Before that, streamline deploy to run multiple subcommands with only a single "staging".

Also print the deploy outputs so you know where to find them.