### PR TITLE
bordel: Use tmp-glibc/deploy

### DIFF
--- a/bordel
+++ b/bordel
@@ -81,7 +81,7 @@ else
 fi
 
 CONF_DIR="conf"
-DEPLOY_DIR="deploy"
+DEPLOY_DIR="tmp-glibc/deploy"
 STAGING_DIR="staging"
 REPO_PACKAGES_DIR="packages.main"
 # shellcheck disable=SC2034

--- a/cmds/config
+++ b/cmds/config
@@ -54,9 +54,6 @@ DL_DIR ?= "\${TOPDIR}/downloads"
 
 SSTATE_DIR = "\${TOPDIR}/sstate-cache"
 
-# Set DEPLOY_DIR outside of TMPDIR
-DEPLOY_DIR = "\${TOPDIR}/${DEPLOY_DIR}"
-
 export CCACHE_DIR = "\${TOPDIR}/ccache"
 CCACHE_TARGET_DIR = "\${CACHE_DIR}"
 


### PR DESCRIPTION
bitbake expects deploy under tmp-glibc.  When you delete tmp-glibc, it
complains when it finds deploy already populated.  Put deploy back under
tmp-glibc.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

This may not be backwards compatible, but there are clearly issues with deploy being a sibling to tmp-glibc.  Users can always clear the two directories, update build-*/conf/auto.conf to remove DEPLOY_DIR, and rebuild.