### PR TITLE
[ghc8] Add new Debian 11 (Bullseye) Dockerfile

### DIFF
--- a/Dockerfiles/openxt-bullseye-oe64
+++ b/Dockerfiles/openxt-bullseye-oe64
@@ -1,0 +1,54 @@
+FROM multiarch/debian-debootstrap:amd64-bullseye
+MAINTAINER Daniel P. Smith <dpsmith@apertussolutions.com>
+
+ARG UNAME=build
+ARG UID=1000
+ARG GID=1000
+
+RUN sed -i "/bullseye-updates/d" /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -yq \
+        openssh-server openssl \
+        sed wget cvs subversion git-core coreutils \
+        unzip texi2html texinfo docbook-utils gawk diffstat \
+        help2man make gcc build-essential g++ desktop-file-utils chrpath cpio \
+        screen bash-completion python3 iputils-ping \
+        guilt iasl quilt bin86 \
+        bcc libsdl1.2-dev liburi-perl genisoimage policycoreutils unzip vim \
+        rpm curl libncurses5-dev libncursesw5 libc6-dev-i386 libelf-dev \
+        xorriso mtools dosfstools libgmp-dev \
+        file byobu man ca-certificates locales && \
+        rm -rf /var/lib/apt-lists/* && \
+        echo "dash dash/sh boolean false" | debconf-set-selections && \
+        DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
+# Install the required version of GHC
+ARG GHC_VERSION=8.10.7
+RUN cd /tmp && \
+	wget https://downloads.haskell.org/~ghc/${GHC_VERSION}/ghc-${GHC_VERSION}-x86_64-deb9-linux.tar.xz && \
+        tar Jxf ghc-${GHC_VERSION}-x86_64-deb9-linux.tar.xz && \
+        rm ghc-${GHC_VERSION}-x86_64-deb9-linux.tar.xz && \
+        cd ghc-${GHC_VERSION} && \
+        ./configure --prefix=/usr && \
+        make install && \
+        cd /tmp && rm -rf ghc-${GHC_VERSION}
+
+# Add "repo" tool (used by many Yocto-based projects)
+RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && \
+        chmod a+x /usr/local/bin/repo
+
+# Symlink for troublesome packages
+RUN ln -s /lib64/ld-linux-x86-64.so.2 /lib/
+
+RUN useradd -Ums /bin/bash -l -p '""' -u $UID $UNAME
+
+# Add quilt config files
+ADD root/home/build/.quiltrc /home/build/.quiltrc
+ADD root/home/build/oxt-patch.header /home/build/oxt-patch.header
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.utf8
+USER $UNAME
+WORKDIR /home/$UNAME
+ENTRYPOINT ["/bin/bash"]

--- a/Dockerfiles/openxt-master
+++ b/Dockerfiles/openxt-master
@@ -1,1 +1,1 @@
-openxt-buster-oe64
+openxt-bullseye-oe64


### PR DESCRIPTION
GHC8 requires a version of glibc that isn't available in Debian 10. Add a new Dockerfile and update our master symlink.

The only differences between this Dockerfile and the Buster Dockerfile are the GHC version differences and the removal of python-pysqlite2, which no longer exists in apt-get.

The parent PR against xenclient-oe can be found here:

https://github.com/OpenXT/xenclient-oe/pull/1469